### PR TITLE
Add mobile landing offline entry and web password visibility toggle

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -261,6 +261,40 @@ select {
   padding-right: 2.25rem;
 }
 
+.password-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-input-wrapper input {
+  width: 100%;
+  padding-right: 2.5rem;
+}
+
+.password-toggle-btn {
+  position: absolute;
+  right: 0.7rem;
+  background: none;
+  border: none;
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0.3rem 0.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+  transition: color 0.2s ease;
+}
+
+.password-toggle-btn:hover {
+  color: var(--accent);
+}
+
+.password-toggle-btn:active {
+  transform: scale(0.95);
+}
+
 .field-error {
   display: block;
   font-size: 0.8rem;

--- a/frontend/src/pages/SignInPage.jsx
+++ b/frontend/src/pages/SignInPage.jsx
@@ -10,6 +10,7 @@ export default function SignInPage() {
   const [form, setForm] = useState({ email: '', password: '' });
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   // If already authenticated, redirect immediately
   if (isAuthenticated) {
@@ -71,14 +72,24 @@ export default function SignInPage() {
 
           <div className="form-group">
             <label htmlFor="password">Password</label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              placeholder="Your password"
-              value={form.password}
-              onChange={handleChange}
-            />
+            <div className="password-input-wrapper">
+              <input
+                id="password"
+                name="password"
+                type={showPassword ? 'text' : 'password'}
+                placeholder="Your password"
+                value={form.password}
+                onChange={handleChange}
+              />
+              <button
+                type="button"
+                className="password-toggle-btn"
+                onClick={() => setShowPassword(!showPassword)}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? '👁️' : '👁️‍🗨️'}
+              </button>
+            </div>
           </div>
 
           <button

--- a/frontend/src/pages/SignUpPage.jsx
+++ b/frontend/src/pages/SignUpPage.jsx
@@ -19,6 +19,8 @@ export default function SignUpPage() {
   const [globalError, setGlobalError] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -149,15 +151,25 @@ export default function SignUpPage() {
           {/* Password */}
           <div className="form-group">
             <label htmlFor="password">Password</label>
-            <input
-              id="password"
-              name="password"
-              type="password"
-              placeholder="Min. 8 characters"
-              value={form.password}
-              onChange={handleChange}
-              className={errors.password ? 'input-error' : ''}
-            />
+            <div className="password-input-wrapper">
+              <input
+                id="password"
+                name="password"
+                type={showPassword ? 'text' : 'password'}
+                placeholder="Min. 8 characters"
+                value={form.password}
+                onChange={handleChange}
+                className={errors.password ? 'input-error' : ''}
+              />
+              <button
+                type="button"
+                className="password-toggle-btn"
+                onClick={() => setShowPassword(!showPassword)}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? '👁️' : '👁️‍🗨️'}
+              </button>
+            </div>
             {errors.password && (
               <span className="field-error">{errors.password}</span>
             )}
@@ -166,15 +178,25 @@ export default function SignUpPage() {
           {/* Confirm Password */}
           <div className="form-group">
             <label htmlFor="confirm_password">Confirm Password</label>
-            <input
-              id="confirm_password"
-              name="confirm_password"
-              type="password"
-              placeholder="Repeat your password"
-              value={form.confirm_password}
-              onChange={handleChange}
-              className={errors.confirm_password ? 'input-error' : ''}
-            />
+            <div className="password-input-wrapper">
+              <input
+                id="confirm_password"
+                name="confirm_password"
+                type={showConfirmPassword ? 'text' : 'password'}
+                placeholder="Repeat your password"
+                value={form.confirm_password}
+                onChange={handleChange}
+                className={errors.confirm_password ? 'input-error' : ''}
+              />
+              <button
+                type="button"
+                className="password-toggle-btn"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                aria-label={showConfirmPassword ? 'Hide password' : 'Show password'}
+              >
+                {showConfirmPassword ? '👁️' : '👁️‍🗨️'}
+              </button>
+            </div>
             {errors.confirm_password && (
               <span className="field-error">{errors.confirm_password}</span>
             )}

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/LandingActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/LandingActivity.kt
@@ -3,6 +3,7 @@ package com.bounswe2026group8.emergencyhub.ui
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import android.widget.Toast
 import com.bounswe2026group8.emergencyhub.R
 import com.bounswe2026group8.emergencyhub.auth.TokenManager
 import com.google.android.material.button.MaterialButton
@@ -36,6 +37,10 @@ class LandingActivity : AppCompatActivity() {
 
         findViewById<MaterialButton>(R.id.btnSignIn).setOnClickListener {
             startActivity(Intent(this, SignInActivity::class.java))
+        }
+
+        findViewById<MaterialButton>(R.id.btnOfflineInfo).setOnClickListener {
+            Toast.makeText(this, "Offline Info — coming soon!", Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/mobile/app/src/main/res/layout/activity_landing.xml
+++ b/mobile/app/src/main/res/layout/activity_landing.xml
@@ -71,6 +71,16 @@
             android:textSize="16sp"
             style="@style/Widget.EmergencyHub.Button.Secondary" />
 
+        <!-- Offline Info button -->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnOfflineInfo"
+            android:layout_width="match_parent"
+            android:layout_height="52dp"
+            android:text="@string/feature_offline"
+            android:textSize="16sp"
+            android:layout_marginTop="12dp"
+            style="@style/Widget.EmergencyHub.Button.Secondary" />
+
         <!-- Spacer -->
         <View
             android:layout_width="0dp"

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -42,4 +42,12 @@
     <string name="feature_profile_desc">Manage your account</string>
     <string name="feature_offline">Offline Info</string>
     <string name="feature_offline_desc">Critical data access</string>
+
+    <!-- Offline Info screen -->
+    <string name="offline_info_title">Offline Info</string>
+    <string name="offline_info_heading">Emergency Preparedness Resources</string>
+    <string name="offline_info_desc">Access critical offline information to prepare for emergencies and protect yourself and your community.</string>
+    <string name="offline_info_tips_title">Key Resources</string>
+    <string name="offline_info_tips">• Emergency contact numbers\n• First aid basics\n• Evacuation procedures\n• Safety checklists\n• Community resources</string>
+    <string name="back">Back</string>
 </resources>


### PR DESCRIPTION
## Description

This PR introduces two small UI/UX improvements within the authentication subgroup scope:

1. Adds an Offline Info entry point to the mobile landing screen
2. Adds password visibility toggles to the web Sign In and Sign Up forms

On mobile, the new landing page Offline Info entry allows users to access the same placeholder behavior used by the Dashboard Offline Info card, without introducing a dedicated Offline Info screen. This keeps the behavior consistent with other not-yet-implemented feature entries.

On web, users can now optionally reveal/hide password input using an eye icon in authentication forms.

## Related Issues

Fixes #139 
Fixes #108 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code Refactoring (no functional changes, no api changes)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] The commit message follows our guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [x] New and existing tests pass locally with my changes.