### PR TITLE
feat: add image upload for help requests creation (mobile)

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
     <application
         android:allowBackup="true"

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ApiService.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ApiService.kt
@@ -140,6 +140,12 @@ interface ApiService {
         @Part images: List<MultipartBody.Part>
     ): Response<UploadImagesResponse>
 
+    @Multipart
+    @POST("/help-requests/upload/")
+    suspend fun uploadHelpRequestImages(
+        @Part images: List<MultipartBody.Part>
+    ): Response<UploadImagesResponse>
+
     @POST("/accounts/fcm-token/")
     suspend fun updateFcmToken(@Body body: FcmTokenRequest): Response<Void>
 }

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/HelpRequestModels.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/HelpRequestModels.kt
@@ -49,6 +49,7 @@ data class CreateHelpRequest(
     val urgency: String,
     val title: String,
     val description: String,
+    @SerializedName("image_urls") val imageUrls: List<String> = emptyList(),
     val latitude: String? = null,
     val longitude: String? = null,
     @SerializedName("location_text") val locationText: String? = null
@@ -64,6 +65,7 @@ data class HelpRequestDetail(
     val author: HelpRequestAuthor,
     val title: String,
     val description: String,
+    @SerializedName("image_urls") val imageUrls: List<String> = emptyList(),
     val latitude: String?,
     val longitude: String?,
     @SerializedName("location_text") val locationText: String?,

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/CreateHelpRequestActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/CreateHelpRequestActivity.kt
@@ -1,11 +1,22 @@
 package com.bounswe2026group8.emergencyhub.ui
 
 import android.Manifest
+import android.app.Activity
+import android.content.ContentValues
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.MediaStore
+import android.provider.OpenableColumns
+import android.view.LayoutInflater
+import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
+import android.widget.HorizontalScrollView
+import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
@@ -16,19 +27,24 @@ import com.bounswe2026group8.emergencyhub.R
 import com.bounswe2026group8.emergencyhub.api.CreateHelpRequest
 import com.bounswe2026group8.emergencyhub.api.RetrofitClient
 import com.bounswe2026group8.emergencyhub.auth.TokenManager
+import com.bumptech.glide.Glide
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
 import com.google.android.gms.tasks.CancellationTokenSource
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
 import kotlinx.coroutines.launch
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
  * Form screen for creating a new help request.
  *
- * Collects title, description, category, urgency, and optional location
- * (text and/or GPS coordinates). On successful submission the user is
- * returned to the list screen with a success message.
+ * Collects title, description, category, urgency, optional location
+ * (text and/or GPS coordinates), and optional images. Images are uploaded
+ * to POST /help-requests/upload/ before the form is submitted; the returned
+ * URLs are attached to the request payload.
  */
 class CreateHelpRequestActivity : AppCompatActivity() {
 
@@ -42,19 +58,71 @@ class CreateHelpRequestActivity : AppCompatActivity() {
     private lateinit var btnUseLocation: MaterialButton
     private lateinit var txtLocationStatus: TextView
 
+    // Image upload views
+    private lateinit var btnUploadImages: MaterialButton
+    private lateinit var btnCaptureImage: MaterialButton
+    private lateinit var txtUploadStatus: TextView
+    private lateinit var imagePreviewScroll: HorizontalScrollView
+    private lateinit var imagePreviewContainer: LinearLayout
+
     /** GPS coordinates captured via "Use My Location". */
     private var capturedLat: Double? = null
     private var capturedLng: Double? = null
+
+    /** URLs returned by the upload endpoint, to be sent with the create request. */
+    private val uploadedImageUrls = mutableListOf<String>()
+
+    /** URI where the camera photo will be saved (needed to retrieve it after capture). */
+    private var cameraImageUri: Uri? = null
 
     /** Launcher for the location permission request. */
     private val locationPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
-        if (granted) {
-            fetchCurrentLocation()
-        } else {
-            Toast.makeText(this, "Location permission denied", Toast.LENGTH_SHORT).show()
+        if (granted) fetchCurrentLocation()
+        else Toast.makeText(this, "Location permission denied", Toast.LENGTH_SHORT).show()
+    }
+
+    /** Launcher for gallery image picker (multi-select). */
+    private val galleryPickerLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val clipData = result.data?.clipData
+            val singleUri = result.data?.data
+            val uris = mutableListOf<Uri>()
+            if (clipData != null) {
+                for (i in 0 until clipData.itemCount) uris.add(clipData.getItemAt(i).uri)
+            } else if (singleUri != null) {
+                uris.add(singleUri)
+            }
+            if (uris.isNotEmpty()) uploadImages(uris)
         }
+    }
+
+    /** Launcher for camera capture. */
+    private val cameraLauncher = registerForActivityResult(
+        ActivityResultContracts.TakePicture()
+    ) { success ->
+        if (success) {
+            cameraImageUri?.let { uploadImages(listOf(it)) }
+        }
+    }
+
+    /** Launcher for camera permission request. */
+    private val cameraPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) launchCamera()
+        else Toast.makeText(this, "Camera permission denied", Toast.LENGTH_SHORT).show()
+    }
+
+    /** Launcher for storage permission (Android ≤ 12). */
+    private val storagePermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) launchGallery()
+        else Toast.makeText(this, "Storage permission denied", Toast.LENGTH_SHORT).show()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -78,22 +146,35 @@ class CreateHelpRequestActivity : AppCompatActivity() {
         btnSubmit = findViewById(R.id.btnSubmit)
         btnUseLocation = findViewById(R.id.btnUseLocation)
         txtLocationStatus = findViewById(R.id.txtLocationStatus)
+        btnUploadImages = findViewById(R.id.btnUploadImages)
+        btnCaptureImage = findViewById(R.id.btnCaptureImage)
+        txtUploadStatus = findViewById(R.id.txtUploadStatus)
+        imagePreviewScroll = findViewById(R.id.imagePreviewScroll)
+        imagePreviewContainer = findViewById(R.id.imagePreviewContainer)
 
         // Back button
         findViewById<MaterialButton>(R.id.btnBack).setOnClickListener { finish() }
 
-        // Category dropdown — no default so the hint shows as placeholder
-        val categoryLabels = arrayOf("Medical", "Food", "Shelter", "Transport")
-        val categoryAdapter = ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, categoryLabels)
+        // Category dropdown
+        val categoryAdapter = ArrayAdapter(
+            this, android.R.layout.simple_dropdown_item_1line,
+            arrayOf("Medical", "Food", "Shelter", "Transport")
+        )
         dropdownCategory.setAdapter(categoryAdapter)
 
-        // Urgency dropdown — no default so the hint shows as placeholder
-        val urgencyLabels = arrayOf("Low", "Medium", "High")
-        val urgencyAdapter = ArrayAdapter(this, android.R.layout.simple_dropdown_item_1line, urgencyLabels)
+        // Urgency dropdown
+        val urgencyAdapter = ArrayAdapter(
+            this, android.R.layout.simple_dropdown_item_1line,
+            arrayOf("Low", "Medium", "High")
+        )
         dropdownUrgency.setAdapter(urgencyAdapter)
 
         // GPS location
         btnUseLocation.setOnClickListener { requestLocation() }
+
+        // Image buttons
+        btnUploadImages.setOnClickListener { requestGallery() }
+        btnCaptureImage.setOnClickListener { requestCamera() }
 
         // Submit
         btnSubmit.setOnClickListener { attemptSubmit() }
@@ -145,6 +226,140 @@ class CreateHelpRequestActivity : AppCompatActivity() {
             }
     }
 
+    // ── Image upload ─────────────────────────────────────────────────────
+
+    /** Requests storage permission (≤ API 32) or goes straight to the picker (API 33+). */
+    private fun requestGallery() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // READ_MEDIA_IMAGES granted at install on Android 13+; no runtime prompt needed
+            launchGallery()
+        } else {
+            val permission = Manifest.permission.READ_EXTERNAL_STORAGE
+            if (ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED) {
+                launchGallery()
+            } else {
+                storagePermissionLauncher.launch(permission)
+            }
+        }
+    }
+
+    private fun launchGallery() {
+        val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+            type = "image/*"
+            putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+            addCategory(Intent.CATEGORY_OPENABLE)
+        }
+        galleryPickerLauncher.launch(Intent.createChooser(intent, "Select Images"))
+    }
+
+    /** Requests CAMERA permission and then launches the camera. */
+    private fun requestCamera() {
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA)
+            == PackageManager.PERMISSION_GRANTED
+        ) {
+            launchCamera()
+        } else {
+            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    private fun launchCamera() {
+        // Create a MediaStore entry so the photo lands in the shared Pictures folder.
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+            put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/EmergencyHub")
+        }
+        val uri = contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+        if (uri == null) {
+            Toast.makeText(this, "Could not create image file", Toast.LENGTH_SHORT).show()
+            return
+        }
+        cameraImageUri = uri
+        cameraLauncher.launch(uri)
+    }
+
+    /**
+     * Uploads the given URIs to POST /help-requests/upload/ and appends the
+     * returned URLs to [uploadedImageUrls].
+     */
+    private fun uploadImages(uris: List<Uri>) {
+        btnUploadImages.isEnabled = false
+        btnCaptureImage.isEnabled = false
+        txtUploadStatus.text = "Uploading ${uris.size} image(s)…"
+        txtUploadStatus.visibility = View.VISIBLE
+
+        val parts = mutableListOf<MultipartBody.Part>()
+        for (uri in uris) {
+            val bytes = contentResolver.openInputStream(uri)?.readBytes() ?: continue
+            val mimeType = contentResolver.getType(uri) ?: "image/jpeg"
+            val fileName = getFileName(uri) ?: "image.jpg"
+            val requestBody = bytes.toRequestBody(mimeType.toMediaType())
+            parts.add(MultipartBody.Part.createFormData("images", fileName, requestBody))
+        }
+
+        lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.getService(this@CreateHelpRequestActivity)
+                    .uploadHelpRequestImages(parts)
+
+                if (response.isSuccessful) {
+                    val urls = response.body()?.urls ?: emptyList()
+                    uploadedImageUrls.addAll(urls)
+                    refreshImagePreviews()
+                    txtUploadStatus.text = "${uploadedImageUrls.size} image(s) attached"
+                } else {
+                    txtUploadStatus.text = "Upload failed"
+                }
+            } catch (e: Exception) {
+                txtUploadStatus.text = "Upload error: ${e.message}"
+            } finally {
+                btnUploadImages.isEnabled = true
+                btnCaptureImage.isEnabled = true
+            }
+        }
+    }
+
+    private fun getFileName(uri: Uri): String? {
+        var name: String? = null
+        contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (idx >= 0 && cursor.moveToFirst()) name = cursor.getString(idx)
+        }
+        return name
+    }
+
+    /** Rebuilds the horizontal image preview strip from [uploadedImageUrls]. */
+    private fun refreshImagePreviews() {
+        imagePreviewContainer.removeAllViews()
+        if (uploadedImageUrls.isEmpty()) {
+            imagePreviewScroll.visibility = View.GONE
+            return
+        }
+        imagePreviewScroll.visibility = View.VISIBLE
+
+        for ((index, url) in uploadedImageUrls.withIndex()) {
+            val itemView = LayoutInflater.from(this)
+                .inflate(R.layout.item_image_preview, imagePreviewContainer, false)
+
+            Glide.with(this)
+                .load(RetrofitClient.resolveImageUrl(url))
+                .centerCrop()
+                .into(itemView.findViewById<ImageView>(R.id.imgPreview))
+
+            itemView.findViewById<TextView>(R.id.btnRemoveImage).setOnClickListener {
+                uploadedImageUrls.removeAt(index)
+                refreshImagePreviews()
+                if (uploadedImageUrls.isEmpty()) {
+                    txtUploadStatus.visibility = View.GONE
+                } else {
+                    txtUploadStatus.text = "${uploadedImageUrls.size} image(s) attached"
+                }
+            }
+
+            imagePreviewContainer.addView(itemView)
+        }
+    }
+
     // ── Form submission ──────────────────────────────────────────────────
 
     private fun attemptSubmit() {
@@ -194,6 +409,7 @@ class CreateHelpRequestActivity : AppCompatActivity() {
             urgency = urgency,
             title = title,
             description = description,
+            imageUrls = uploadedImageUrls.toList(),
             latitude = capturedLat?.let { "%.6f".format(it) },
             longitude = capturedLng?.let { "%.6f".format(it) },
             locationText = locationText
@@ -224,7 +440,6 @@ class CreateHelpRequestActivity : AppCompatActivity() {
                     tokenManager.clear()
                     navigateToLanding()
                 } else {
-                    // Show server validation errors
                     val errorText = response.errorBody()?.string() ?: "Submission failed."
                     Toast.makeText(
                         this@CreateHelpRequestActivity,

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestDetailActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestDetailActivity.kt
@@ -4,6 +4,9 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.format.DateUtils
 import android.view.View
+import android.widget.HorizontalScrollView
+import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
@@ -18,6 +21,7 @@ import com.bounswe2026group8.emergencyhub.api.HelpRequestComment
 import com.bounswe2026group8.emergencyhub.api.HelpRequestDetail
 import com.bounswe2026group8.emergencyhub.api.RetrofitClient
 import com.bounswe2026group8.emergencyhub.auth.TokenManager
+import com.bumptech.glide.Glide
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.textfield.TextInputEditText
@@ -60,6 +64,10 @@ class HelpRequestDetailActivity : AppCompatActivity() {
     private lateinit var txtMapLocationText: TextView
     private lateinit var txtLocationOnly: TextView
     private var mapView: MapView? = null
+
+    // Images
+    private lateinit var imageGalleryScroll: HorizontalScrollView
+    private lateinit var imageGallery: LinearLayout
 
     // Comments
     private lateinit var txtCommentsHeader: TextView
@@ -137,6 +145,8 @@ class HelpRequestDetailActivity : AppCompatActivity() {
         mapView = findViewById(R.id.mapView)
         txtMapLocationText = findViewById(R.id.txtMapLocationText)
         txtLocationOnly = findViewById(R.id.txtLocationOnly)
+        imageGalleryScroll = findViewById(R.id.imageGalleryScroll)
+        imageGallery = findViewById(R.id.imageGallery)
 
         txtCommentsHeader = findViewById(R.id.txtCommentsHeader)
         recyclerComments = findViewById(R.id.recyclerComments)
@@ -218,6 +228,30 @@ class HelpRequestDetailActivity : AppCompatActivity() {
             else -> {
                 txtDetailStatus.text = getString(R.string.status_open)
             }
+        }
+
+        // Images
+        if (detail.imageUrls.isNotEmpty()) {
+            imageGalleryScroll.visibility = View.VISIBLE
+            imageGallery.removeAllViews()
+            val density = resources.displayMetrics.density
+            val sizePx = (140 * density).toInt()
+            val marginPx = (8 * density).toInt()
+            for (url in detail.imageUrls) {
+                val imgView = ImageView(this).apply {
+                    layoutParams = LinearLayout.LayoutParams(sizePx, sizePx).also {
+                        it.marginEnd = marginPx
+                    }
+                    scaleType = ImageView.ScaleType.CENTER_CROP
+                }
+                Glide.with(this)
+                    .load(RetrofitClient.resolveImageUrl(url))
+                    .centerCrop()
+                    .into(imgView)
+                imageGallery.addView(imgView)
+            }
+        } else {
+            imageGalleryScroll.visibility = View.GONE
         }
 
         // Map / location

--- a/mobile/app/src/main/res/layout/activity_create_help_request.xml
+++ b/mobile/app/src/main/res/layout/activity_create_help_request.xml
@@ -179,6 +179,65 @@
 
         </LinearLayout>
 
+        <!-- ── Images (optional) ──────────────────────────────────────────── -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/images_optional"
+            android:textColor="@color/text_secondary"
+            android:textSize="14sp"
+            android:layout_marginBottom="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="8dp">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnUploadImages"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:text="@string/upload_from_gallery"
+                android:textSize="13sp"
+                android:layout_marginEnd="8dp"
+                style="@style/Widget.EmergencyHub.Button.Secondary" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnCaptureImage"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:text="@string/take_photo"
+                android:textSize="13sp"
+                style="@style/Widget.EmergencyHub.Button.Secondary" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/txtUploadStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/text_secondary"
+            android:textSize="13sp"
+            android:layout_marginBottom="8dp"
+            android:visibility="gone" />
+
+        <HorizontalScrollView
+            android:id="@+id/imagePreviewScroll"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:id="@+id/imagePreviewContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="80dp"
+                android:orientation="horizontal" />
+
+        </HorizontalScrollView>
+
         <!-- ── Submit button ───────────────────────────────────────────────── -->
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btnSubmit"

--- a/mobile/app/src/main/res/layout/activity_help_request_detail.xml
+++ b/mobile/app/src/main/res/layout/activity_help_request_detail.xml
@@ -131,6 +131,22 @@
                         android:lineSpacingExtra="4dp"
                         android:layout_marginBottom="12dp" />
 
+                    <!-- Images (hidden when none) -->
+                    <HorizontalScrollView
+                        android:id="@+id/imageGalleryScroll"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="12dp"
+                        android:visibility="gone">
+
+                        <LinearLayout
+                            android:id="@+id/imageGallery"
+                            android:layout_width="wrap_content"
+                            android:layout_height="140dp"
+                            android:orientation="horizontal" />
+
+                    </HorizontalScrollView>
+
                     <!-- Author + time -->
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -73,6 +73,9 @@
     <string name="submitting">Submitting…</string>
     <string name="submit">Submit</string>
     <string name="help_request_created">Help request created!</string>
+    <string name="images_optional">Images (optional)</string>
+    <string name="upload_from_gallery">Gallery</string>
+    <string name="take_photo">Camera</string>
 
     <!-- Help Request Detail -->
     <string name="help_request_detail_title">Help Request</string>


### PR DESCRIPTION
## Description
Adds image upload support to the help request creation and detail screens on Android.
Users can select images from their gallery, preview them before submitting, 
and view attached images in the request detail screen.

## Related Issues
Closes #156 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] The commit message follows our guidelines.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [x] New and existing tests pass locally with my changes.
