### PR TITLE
fix: Help Requests Created on Mobile Now Appears in the Hub

### DIFF
--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/CreateHelpRequestActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/CreateHelpRequestActivity.kt
@@ -190,6 +190,7 @@ class CreateHelpRequestActivity : AppCompatActivity() {
         btnSubmit.text = getString(R.string.submitting)
 
         val request = CreateHelpRequest(
+            hub = tokenManager.getUser()?.hub?.id,
             category = category,
             urgency = urgency,
             title = title,


### PR DESCRIPTION
## Description

Fixes help requests created from mobile not appearing in the hub's 
request list. The hub_id was not being included in the POST /help-requests/ 
payload, causing requests to be created without hub association.

## Related Issues
Fixes #164 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] The commit message follows our guidelines.
- [x] My changes generate no new warnings or errors.
- [x] New and existing tests pass locally with my changes.
