### PR TITLE
feat: allow users to delete their own help requests and comments

### DIFF
--- a/backend/help_requests/tests.py
+++ b/backend/help_requests/tests.py
@@ -695,3 +695,64 @@ class ImageUploadTests(HelpTestBase):
         img = self._make_image()
         res = self.anon.post(self.UPLOAD_URL, {'images': img}, format='multipart')
         self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+# ── Comment Delete Tests ──────────────────────────────────────────────────────
+
+class HelpCommentDeleteTests(HelpTestBase):
+    """
+    Tests for DELETE /help-requests/comments/{pk}/.
+
+    Verifies author-only enforcement, comment_count decrement, and error cases.
+    """
+
+    def _create_comment(self, client=None, request_pk=None, content='Test comment'):
+        """Helper to create a comment and return its data."""
+        client = client or self.standard_client
+        res = client.post(
+            f'/help-requests/{request_pk}/comments/',
+            {'content': content},
+            format='json',
+        )
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        return res.data
+
+    def test_author_can_delete_own_comment(self):
+        """Comment author can delete their own comment — returns 204."""
+        request_pk = self._create_help_request().data['id']
+        comment = self._create_comment(request_pk=request_pk)
+
+        res = self.standard_client.delete(f'/help-requests/comments/{comment["id"]}/')
+        self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(HelpComment.objects.filter(pk=comment['id']).exists())
+
+    def test_delete_decrements_comment_count(self):
+        """Deleting a comment decrements comment_count on the parent request."""
+        request_pk = self._create_help_request().data['id']
+        comment = self._create_comment(request_pk=request_pk)
+        self.assertEqual(HelpRequest.objects.get(pk=request_pk).comment_count, 1)
+
+        self.standard_client.delete(f'/help-requests/comments/{comment["id"]}/')
+        self.assertEqual(HelpRequest.objects.get(pk=request_pk).comment_count, 0)
+
+    def test_non_author_cannot_delete_comment(self):
+        """A user who did not write the comment gets 403."""
+        request_pk = self._create_help_request().data['id']
+        comment = self._create_comment(request_pk=request_pk)
+
+        res = self.expert_client.delete(f'/help-requests/comments/{comment["id"]}/')
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(HelpComment.objects.filter(pk=comment['id']).exists())
+
+    def test_unauthenticated_cannot_delete_comment(self):
+        """Unauthenticated request returns 401."""
+        request_pk = self._create_help_request().data['id']
+        comment = self._create_comment(request_pk=request_pk)
+
+        res = self.anon.delete(f'/help-requests/comments/{comment["id"]}/')
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_delete_nonexistent_comment_returns_404(self):
+        """Deleting a comment that does not exist returns 404."""
+        res = self.standard_client.delete('/help-requests/comments/99999/')
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/help_requests/urls.py
+++ b/backend/help_requests/urls.py
@@ -13,6 +13,7 @@ from .views import (
     HelpRequestDetailView,
     HelpRequestStatusView,
     HelpCommentListCreateView,
+    HelpCommentDeleteView,
     HelpOfferListCreateView,
     HelpOfferDeleteView,
     ImageUploadView,
@@ -25,6 +26,7 @@ help_request_urlpatterns = [
     path('<int:pk>/', HelpRequestDetailView.as_view(), name='help-request-detail'),
     path('<int:pk>/status/', HelpRequestStatusView.as_view(), name='help-request-status'),
     path('<int:request_pk>/comments/', HelpCommentListCreateView.as_view(), name='help-comment-list-create'),
+    path('comments/<int:pk>/', HelpCommentDeleteView.as_view(), name='help-comment-delete'),
 ]
 
 # Mounted at /help-offers/ by backend/urls.py.

--- a/backend/help_requests/views.py
+++ b/backend/help_requests/views.py
@@ -23,7 +23,7 @@ from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 
 from accounts.models import User
-from .models import HelpRequest, HelpOffer
+from .models import HelpRequest, HelpComment, HelpOffer
 from .serializers import (
     HelpRequestListSerializer,
     HelpRequestDetailSerializer,
@@ -204,6 +204,31 @@ class HelpCommentListCreateView(APIView):
                 update_status_on_expert_comment(help_request)
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class HelpCommentDeleteView(APIView):
+    """
+    DELETE /help-requests/comments/{pk}/ — delete a comment (author only).
+
+    Decrements comment_count on the parent HelpRequest atomically so the
+    denormalised counter stays in sync, matching the increment in HelpCommentListCreateView.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def delete(self, request, pk):
+        comment = get_object_or_404(HelpComment, pk=pk)
+        if comment.author != request.user:
+            return Response(
+                {'detail': 'You can only delete your own comments.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        with transaction.atomic():
+            # Keep comment_count in sync using F() to avoid race conditions.
+            HelpRequest.objects.filter(pk=comment.request_id).update(
+                comment_count=F('comment_count') - 1,
+            )
+            comment.delete()
+        return Response({'detail': 'Comment deleted.'}, status=status.HTTP_204_NO_CONTENT)
 
 
 # ── Help Offers ────────────────────────────────────────────────────────────────

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -857,6 +857,9 @@ select {
 .post-owner-actions {
   display: flex;
   gap: 0.5rem;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1.25rem;
 }
 
 .btn-danger {
@@ -1214,7 +1217,6 @@ textarea:focus {
 }
 
 .comment-delete {
-  margin-left: auto;
   background: none;
   border: none;
   color: var(--text-muted);
@@ -1557,7 +1559,6 @@ textarea:focus {
 }
 
 .help-detail-resolve-btn {
-  margin-top: 1.25rem;
 }
 
 .help-detail-location-text {
@@ -1611,8 +1612,14 @@ textarea:focus {
 
 .help-detail-comment-date {
   color: var(--text-muted);
-  margin-left: auto;
   font-weight: 400;
+}
+
+.comment-right-group {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
 }
 
 .help-detail-comment p {

--- a/frontend/src/pages/HelpRequestDetailPage.jsx
+++ b/frontend/src/pages/HelpRequestDetailPage.jsx
@@ -9,7 +9,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { getHelpRequest, getHelpComments, createHelpComment, updateHelpRequestStatus, resolveImageUrl } from '../services/api';
+import { getHelpRequest, getHelpComments, createHelpComment, updateHelpRequestStatus, deleteHelpRequest, deleteHelpComment, resolveImageUrl } from '../services/api';
 import { MapContainer, TileLayer, Marker } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
@@ -75,6 +75,9 @@ export default function HelpRequestDetailPage() {
   // Resolve button state
   const [resolving, setResolving] = useState(false);
 
+  // Delete request confirmation modal state
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
   // Fetch request detail and comments in parallel on mount.
   useEffect(() => {
     setLoading(true);
@@ -107,6 +110,22 @@ export default function HelpRequestDetailPage() {
       setCommentError(data.detail || 'Failed to post comment.');
     }
     setSubmitting(false);
+  };
+
+  /** Deletes the help request and navigates back (author only). */
+  const handleDeleteRequest = async () => {
+    setShowDeleteConfirm(false);
+    const { ok } = await deleteHelpRequest(id);
+    if (ok) navigate(-1);
+  };
+
+  /** Removes a single comment optimistically (comment author only). */
+  const handleDeleteComment = async (commentId) => {
+    const { ok } = await deleteHelpComment(commentId);
+    if (ok) {
+      setComments((prev) => prev.filter((c) => c.id !== commentId));
+      setHelpRequest((r) => r && { ...r, comment_count: Math.max(0, r.comment_count - 1) });
+    }
   };
 
   /** Marks the help request as RESOLVED (author only). */
@@ -195,17 +214,41 @@ export default function HelpRequestDetailPage() {
           <span>{formatDate(helpRequest.created_at)}</span>
         </div>
 
-        {/* Resolve button — only visible to the author when not already resolved */}
-        {helpRequest.author.id === user.id && helpRequest.status !== 'RESOLVED' && (
-          <button
-            className="btn btn-primary btn-sm help-detail-resolve-btn"
-            onClick={handleResolve}
-            disabled={resolving}
-          >
-            {resolving ? 'Resolving...' : 'Mark as Resolved'}
-          </button>
+        {/* Author actions — resolve and delete */}
+        {helpRequest.author.id === user.id && (
+          <div className="post-owner-actions">
+            {helpRequest.status !== 'RESOLVED' && (
+              <button
+                className="btn btn-primary btn-sm help-detail-resolve-btn"
+                onClick={handleResolve}
+                disabled={resolving}
+              >
+                {resolving ? 'Resolving...' : 'Mark as Resolved'}
+              </button>
+            )}
+            <button
+              className="btn btn-danger btn-sm"
+              onClick={() => setShowDeleteConfirm(true)}
+            >
+              Delete
+            </button>
+          </div>
         )}
       </div>
+
+      {/* Delete confirmation modal */}
+      {showDeleteConfirm && (
+        <div className="modal-overlay" onClick={() => setShowDeleteConfirm(false)}>
+          <div className="modal-card" onClick={(e) => e.stopPropagation()}>
+            <h3>Delete Request</h3>
+            <p className="modal-body-text">Are you sure you want to delete this help request? This cannot be undone.</p>
+            <div className="modal-actions">
+              <button className="btn btn-danger btn-sm" onClick={handleDeleteRequest}>Delete</button>
+              <button className="btn btn-secondary btn-sm" onClick={() => setShowDeleteConfirm(false)}>Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Location section */}
       {(hasCoords || helpRequest.location_text) && (
@@ -252,7 +295,18 @@ export default function HelpRequestDetailPage() {
                   {c.author.role === 'EXPERT' && (
                     <span className="badge badge-expert-responding">Expert</span>
                   )}
-                  <span className="help-detail-comment-date">{formatDate(c.created_at)}</span>
+                  <div className="comment-right-group">
+                    <span className="help-detail-comment-date">{formatDate(c.created_at)}</span>
+                    {user.id === c.author.id && (
+                      <button
+                        className="comment-delete"
+                        onClick={() => handleDeleteComment(c.id)}
+                        title="Delete comment"
+                      >
+                        &times;
+                      </button>
+                    )}
+                  </div>
                 </div>
                 <p>{c.content}</p>
               </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -256,6 +256,16 @@ export function deleteHelpOffer(id) {
   return request(`/help-offers/${id}/`, { method: 'DELETE' });
 }
 
+/** DELETE /help-requests/{id}/ — delete a help request (author only). */
+export function deleteHelpRequest(id) {
+  return request(`/help-requests/${id}/`, { method: 'DELETE' });
+}
+
+/** DELETE /help-requests/comments/{id}/ — delete a help request comment (author only). */
+export function deleteHelpComment(commentId) {
+  return request(`/help-requests/comments/${commentId}/`, { method: 'DELETE' });
+}
+
 // ── Forum ─────────────────────────────────────────────────────────────────────
 
 export function getPosts({ hub, forumType, author } = {}) {

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ApiService.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ApiService.kt
@@ -54,6 +54,11 @@ interface ApiService {
         @Path("id") id: Int
     ): Response<HelpRequestDetail>
 
+    @DELETE("/help-requests/{id}/")
+    suspend fun deleteHelpRequest(
+        @Path("id") id: Int
+    ): Response<ResponseBody?>
+
     // ── Help Request Comments ────────────────────────────────────────────
 
     @GET("/help-requests/{id}/comments/")
@@ -66,6 +71,11 @@ interface ApiService {
         @Path("id") requestId: Int,
         @Body body: CreateCommentRequest
     ): Response<HelpRequestComment>
+
+    @DELETE("/help-requests/comments/{id}/")
+    suspend fun deleteHelpRequestComment(
+        @Path("id") commentId: Int
+    ): Response<ResponseBody?>
 
     // ── Help Offers ──────────────────────────────────────────────────────
 

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestCommentAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestCommentAdapter.kt
@@ -16,9 +16,13 @@ import java.util.TimeZone
  * RecyclerView adapter for the comment list on the help-request detail screen.
  *
  * Expert authors get a visible badge and their expertise field shown.
+ * The comment author gets a Delete button; [onDeleteClick] is invoked on tap
+ * and the caller is responsible for the actual API call and list update.
  */
 class HelpRequestCommentAdapter(
-    private var items: List<HelpRequestComment>
+    private var items: List<HelpRequestComment>,
+    private val currentUserId: Int? = null,
+    private val onDeleteClick: (HelpRequestComment) -> Unit = {},
 ) : RecyclerView.Adapter<HelpRequestCommentAdapter.ViewHolder>() {
 
     private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).apply {
@@ -31,6 +35,7 @@ class HelpRequestCommentAdapter(
         val txtExpertiseField: TextView = view.findViewById(R.id.txtExpertiseField)
         val txtCommentContent: TextView = view.findViewById(R.id.txtCommentContent)
         val txtCommentTime: TextView = view.findViewById(R.id.txtCommentTime)
+        val btnDeleteComment: TextView = view.findViewById(R.id.btnDeleteComment)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -59,6 +64,14 @@ class HelpRequestCommentAdapter(
             holder.txtExpertBadge.visibility = View.GONE
             holder.txtExpertiseField.visibility = View.GONE
         }
+
+        // Delete button — only visible to the comment author
+        if (currentUserId != null && comment.author.id == currentUserId) {
+            holder.btnDeleteComment.visibility = View.VISIBLE
+            holder.btnDeleteComment.setOnClickListener { onDeleteClick(comment) }
+        } else {
+            holder.btnDeleteComment.visibility = View.GONE
+        }
     }
 
     override fun getItemCount(): Int = items.size
@@ -73,6 +86,15 @@ class HelpRequestCommentAdapter(
     fun addComment(comment: HelpRequestComment) {
         items = items + comment
         notifyItemInserted(items.size - 1)
+    }
+
+    /** Removes a single comment by ID (used after deletion). */
+    fun removeComment(commentId: Int) {
+        val index = items.indexOfFirst { it.id == commentId }
+        if (index != -1) {
+            items = items.toMutableList().also { it.removeAt(index) }
+            notifyItemRemoved(index)
+        }
     }
 
     private fun formatTimeAgo(iso: String): String {

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestDetailActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestDetailActivity.kt
@@ -1,5 +1,6 @@
 package com.bounswe2026group8.emergencyhub.ui
 
+import android.app.AlertDialog
 import android.content.Intent
 import android.os.Bundle
 import android.text.format.DateUtils
@@ -111,6 +112,11 @@ class HelpRequestDetailActivity : AppCompatActivity() {
         findViewById<MaterialButton>(R.id.btnBack).setOnClickListener { finish() }
         btnSendComment.setOnClickListener { submitComment() }
 
+        // Delete request button — shown only after displayDetail() confirms authorship
+        findViewById<MaterialButton>(R.id.btnDeleteRequest).setOnClickListener {
+            confirmDeleteRequest()
+        }
+
         fetchDetail()
         fetchComments()
     }
@@ -157,7 +163,12 @@ class HelpRequestDetailActivity : AppCompatActivity() {
     }
 
     private fun setupRecyclerView() {
-        commentAdapter = HelpRequestCommentAdapter(emptyList())
+        val currentUserId = tokenManager.getUser()?.id
+        commentAdapter = HelpRequestCommentAdapter(
+            items = emptyList(),
+            currentUserId = currentUserId,
+            onDeleteClick = { comment -> confirmDeleteComment(comment.id) },
+        )
         recyclerComments.layoutManager = LinearLayoutManager(this)
         recyclerComments.isNestedScrollingEnabled = false
         recyclerComments.adapter = commentAdapter
@@ -277,6 +288,11 @@ class HelpRequestDetailActivity : AppCompatActivity() {
 
         // Comments header count
         txtCommentsHeader.text = getString(R.string.comments_count_label, detail.commentCount)
+
+        // Show delete button to the request author only
+        val currentUserId = tokenManager.getUser()?.id
+        val btnDelete = findViewById<MaterialButton>(R.id.btnDeleteRequest)
+        btnDelete.visibility = if (currentUserId == detail.author.id) View.VISIBLE else View.GONE
     }
 
     private fun setupMap(lat: Double, lng: Double) {
@@ -336,6 +352,67 @@ class HelpRequestDetailActivity : AppCompatActivity() {
     }
 
     // ── Submit comment ───────────────────────────────────────────────────
+
+    // ── Delete request ───────────────────────────────────────────────────
+
+    /** Shows a confirmation dialog then deletes the help request. */
+    private fun confirmDeleteRequest() {
+        AlertDialog.Builder(this)
+            .setTitle("Delete Help Request")
+            .setMessage("Are you sure you want to delete this help request? This cannot be undone.")
+            .setPositiveButton("Delete") { _, _ -> deleteRequest() }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun deleteRequest() {
+        lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.getService(this@HelpRequestDetailActivity)
+                    .deleteHelpRequest(requestId)
+                if (response.isSuccessful || response.code() == 204) {
+                    Toast.makeText(this@HelpRequestDetailActivity, "Help request deleted.", Toast.LENGTH_SHORT).show()
+                    finish()
+                } else if (response.code() == 403) {
+                    Toast.makeText(this@HelpRequestDetailActivity, "You can only delete your own requests.", Toast.LENGTH_SHORT).show()
+                } else {
+                    Toast.makeText(this@HelpRequestDetailActivity, "Failed to delete request.", Toast.LENGTH_SHORT).show()
+                }
+            } catch (_: Exception) {
+                Toast.makeText(this@HelpRequestDetailActivity, "Network error.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    // ── Delete comment ───────────────────────────────────────────────────
+
+    /** Shows a confirmation dialog then deletes the comment and updates the UI. */
+    private fun confirmDeleteComment(commentId: Int) {
+        AlertDialog.Builder(this)
+            .setTitle("Delete Comment")
+            .setMessage("Are you sure you want to delete this comment?")
+            .setPositiveButton("Delete") { _, _ -> deleteComment(commentId) }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun deleteComment(commentId: Int) {
+        lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.getService(this@HelpRequestDetailActivity)
+                    .deleteHelpRequestComment(commentId)
+                if (response.isSuccessful || response.code() == 204) {
+                    // Re-fetch both comments and detail so the list and count update immediately
+                    fetchComments()
+                    fetchDetail()
+                } else {
+                    Toast.makeText(this@HelpRequestDetailActivity, "Failed to delete comment.", Toast.LENGTH_SHORT).show()
+                }
+            } catch (_: Exception) {
+                Toast.makeText(this@HelpRequestDetailActivity, "Network error.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
 
     private fun submitComment() {
         val content = inputComment.text.toString().trim()

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestListActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestListActivity.kt
@@ -154,12 +154,13 @@ class HelpRequestListActivity : AppCompatActivity() {
         hubSelectorHelper.load()
     }
 
-    /** Re-fetch on resume so lists update after creating a new item. */
+    /** Re-fetch on resume so lists update after creating or deleting an item. */
     override fun onResume() {
         super.onResume()
         if (::hubSelectorHelper.isInitialized) {
             hubSelectorHelper.load()
         }
+        if (activeTab == "requests") fetchHelpRequests() else fetchHelpOffers()
     }
 
     // ── Tab switching ────────────────────────────────────────────────────

--- a/mobile/app/src/main/res/layout/activity_help_request_detail.xml
+++ b/mobile/app/src/main/res/layout/activity_help_request_detail.xml
@@ -47,6 +47,16 @@
                     android:textSize="20sp"
                     android:textStyle="bold" />
 
+                <!-- Delete button — shown only to the request author -->
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnDeleteRequest"
+                    android:layout_width="wrap_content"
+                    android:layout_height="40dp"
+                    android:text="Delete"
+                    android:textSize="13sp"
+                    android:visibility="gone"
+                    style="@style/Widget.EmergencyHub.Button.Secondary" />
+
             </LinearLayout>
 
             <!-- ── Detail card ─────────────────────────────────────────── -->

--- a/mobile/app/src/main/res/layout/item_help_request_comment.xml
+++ b/mobile/app/src/main/res/layout/item_help_request_comment.xml
@@ -69,6 +69,17 @@
         android:lineSpacingExtra="2dp"
         android:layout_marginTop="6dp" />
 
+    <!-- Delete button — only shown to the comment author -->
+    <TextView
+        android:id="@+id/btnDeleteComment"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Delete"
+        android:textColor="@color/urgency_high"
+        android:textSize="12sp"
+        android:layout_marginTop="4dp"
+        android:visibility="gone" />
+
     <!-- Bottom divider -->
     <View
         android:layout_width="match_parent"


### PR DESCRIPTION
## Description

Users can now delete their own help requests and comments on help requests across web and mobile. Backend permission enforcement ensures only the author can delete their own content.

## Related Issues
Closes #171

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have performed a self-review of my own code.
- [x] The commit message follows our guidelines.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [x] New and existing tests pass locally with my changes.

## Notes

Two known UI issues on mobile to be fixed in a follow-up:
- After deleting a comment, the list does not update immediately, it requires leaving and re-entering the screen.
- After deleting a help request, the user is not automatically navigated back to the list screen.

