### PR TITLE
fix: skip expert_responding transition when expert comments on own request

### DIFF
--- a/backend/help_requests/views.py
+++ b/backend/help_requests/views.py
@@ -198,9 +198,9 @@ class HelpCommentListCreateView(APIView):
                 comment_count=F('comment_count') + 1,
             )
 
-            # If the commenter is an expert, promote the request status.
+            # If a *different* expert comments, promote the request status.
             # This call is safe — it won't overwrite RESOLVED status.
-            if request.user.role == User.Role.EXPERT:
+            if request.user.role == User.Role.EXPERT and request.user != help_request.author:
                 update_status_on_expert_comment(help_request)
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## Description
Expert commenting on their own help request was incorrectly triggering 
`expert_responding` status. Now only comments from experts who are not the 
request owner trigger this transition.

## Changes
- Updated comment creation logic in `views.py` to check if the commenter is 
  the request owner before transitioning status

## Related issues

Fixes #188  