### PR TITLE
fix: revert status from expert_responding when last expert comment is deleted

### DIFF
--- a/backend/help_requests/services.py
+++ b/backend/help_requests/services.py
@@ -35,3 +35,36 @@ def update_status_on_expert_comment(help_request):
         help_request.status = HelpRequest.Status.EXPERT_RESPONDING
         return True
     return False
+
+
+def revert_status_on_last_expert_comment_delete(help_request):
+    """
+    If the request is EXPERT_RESPONDING and no expert comments remain after
+    a deletion, revert the status back to OPEN.
+
+    Called after an expert's comment is deleted. The rule is:
+      - EXPERT_RESPONDING -> OPEN  (no expert comments left)
+      - EXPERT_RESPONDING -> no change  (other expert comments still exist)
+      - RESOLVED -> no change  (never revert a resolved request)
+      - OPEN -> no change  (already open)
+
+    Must be called inside the same transaction as the delete so the query
+    reflects the post-deletion state of comments.
+
+    Returns True if the status was changed, False otherwise.
+    """
+    if help_request.status != HelpRequest.Status.EXPERT_RESPONDING:
+        return False
+
+    from accounts.models import User
+    has_expert_comment = help_request.comments.filter(
+        author__role=User.Role.EXPERT
+    ).exists()
+
+    if not has_expert_comment:
+        HelpRequest.objects.filter(pk=help_request.pk).update(
+            status=HelpRequest.Status.OPEN,
+        )
+        help_request.status = HelpRequest.Status.OPEN
+        return True
+    return False

--- a/backend/help_requests/tests.py
+++ b/backend/help_requests/tests.py
@@ -756,3 +756,46 @@ class HelpCommentDeleteTests(HelpTestBase):
         """Deleting a comment that does not exist returns 404."""
         res = self.standard_client.delete('/help-requests/comments/99999/')
         self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_deleting_only_expert_comment_reverts_status_to_open(self):
+        """When the last expert comment is deleted, status reverts from EXPERT_RESPONDING to OPEN."""
+        request_pk = self._create_help_request().data['id']
+
+        # Expert (different from author) comments — promotes status.
+        comment = self._create_comment(client=self.expert_client, request_pk=request_pk)
+        self.assertEqual(
+            HelpRequest.objects.get(pk=request_pk).status,
+            HelpRequest.Status.EXPERT_RESPONDING,
+        )
+
+        # Expert deletes their comment — status should revert.
+        self.expert_client.delete(f'/help-requests/comments/{comment["id"]}/')
+        self.assertEqual(
+            HelpRequest.objects.get(pk=request_pk).status,
+            HelpRequest.Status.OPEN,
+        )
+
+    def test_deleting_expert_comment_with_other_expert_comments_keeps_status(self):
+        """Deleting one expert comment keeps status EXPERT_RESPONDING if another expert comment remains."""
+        # Create a second expert user.
+        expert2 = User.objects.create_user(
+            email='expert2@example.com', full_name='Expert Two',
+            password='Pass1234', hub=self.hub, role=User.Role.EXPERT,
+        )
+        expert2_client = APIClient()
+        expert2_client.credentials(
+            HTTP_AUTHORIZATION=f'Bearer {RefreshToken.for_user(expert2).access_token}'
+        )
+
+        request_pk = self._create_help_request().data['id']
+
+        # Two different experts comment.
+        comment1 = self._create_comment(client=self.expert_client, request_pk=request_pk)
+        self._create_comment(client=expert2_client, request_pk=request_pk)
+
+        # First expert deletes their comment — second expert's comment still exists.
+        self.expert_client.delete(f'/help-requests/comments/{comment1["id"]}/')
+        self.assertEqual(
+            HelpRequest.objects.get(pk=request_pk).status,
+            HelpRequest.Status.EXPERT_RESPONDING,
+        )

--- a/backend/help_requests/views.py
+++ b/backend/help_requests/views.py
@@ -34,7 +34,7 @@ from .serializers import (
     HelpOfferCreateSerializer,
 )
 from .notifications import send_help_request_notification
-from .services import update_status_on_expert_comment
+from .services import update_status_on_expert_comment, revert_status_on_last_expert_comment_delete
 
 
 class HelpRequestListCreateView(APIView):
@@ -222,12 +222,17 @@ class HelpCommentDeleteView(APIView):
                 {'detail': 'You can only delete your own comments.'},
                 status=status.HTTP_403_FORBIDDEN,
             )
+        help_request = comment.request
         with transaction.atomic():
             # Keep comment_count in sync using F() to avoid race conditions.
             HelpRequest.objects.filter(pk=comment.request_id).update(
                 comment_count=F('comment_count') - 1,
             )
             comment.delete()
+            # If an expert's comment was deleted, revert status to OPEN if no
+            # other expert comments remain (query runs post-delete, same tx).
+            if comment.author.role == User.Role.EXPERT:
+                revert_status_on_last_expert_comment_delete(help_request)
         return Response({'detail': 'Comment deleted.'}, status=status.HTTP_204_NO_CONTENT)
 
 


### PR DESCRIPTION
## Description
Deleting the only expert comment on a help request left the status stuck at 
`expert_responding`. Now deletion checks if any expert comments remain and 
reverts to `open` if none do.


## Related Issues
Fixes #192