### PR TITLE
test: update CI pipeline to get test reports and add mobile tests back

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,12 @@ jobs:
           python manage.py test accounts forum help_requests \
             --testrunner=xmlrunner.extra.djangotestrunner.XMLTestRunner \
             --verbosity=2
+          # xmlrunner writes TEST-*.xml into cwd; move them to the expected location
+          mv TEST-*.xml ${{ github.workspace }}/test-reports/backend/ 2>/dev/null || true
+
+      - name: Debug report paths
+        if: always()
+        run: ls -la ${{ github.workspace }}/test-reports/backend/ || echo "Directory not found"
 
       - name: Upload backend test reports
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   test:
@@ -36,6 +40,7 @@ jobs:
         run: |
           cd backend
           pip install -r requirements.txt
+          pip install unittest-xml-reporting pytest pytest-html pytest-django
 
       - name: Run tests
         env:
@@ -46,10 +51,23 @@ jobs:
           DB_PASSWORD: testpass
           DB_HOST: localhost
           DB_PORT: 5432
+          DJANGO_SETTINGS_MODULE: backend.settings
         run: |
+          mkdir -p test-reports/backend
           cd backend
           python manage.py migrate --noinput
-          python manage.py test accounts forum help_requests --verbosity=2
+          pytest accounts forum help_requests \
+            --junitxml=../test-reports/backend/results.xml \
+            --html=../test-reports/backend/report.html \
+            --self-contained-html \
+            -p no:cacheprovider
+
+      - name: Upload backend test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-test-reports
+          path: test-reports/backend/
 
   frontend-test:
     runs-on: ubuntu-latest
@@ -67,12 +85,63 @@ jobs:
       - name: Install dependencies
         run: cd frontend && npm ci
 
+      - name: Install report tools
+        run: cd frontend && npm install jest-junit
+
       - name: Run tests
-        run: cd frontend && npm test -- --ci
+        env:
+          JEST_JUNIT_OUTPUT_DIR: ../test-reports/frontend
+          JEST_JUNIT_OUTPUT_NAME: results.xml
+        run: |
+          mkdir -p test-reports/frontend
+          cd frontend && npm test -- --ci \
+            --reporters=default \
+            --reporters=jest-junit
+
+      - name: Upload frontend test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-test-reports
+          path: test-reports/frontend/
+
+  android-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Write google-services.json
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > mobile/app/google-services.json
+
+      - name: Fix gradlew line endings
+        run: sed -i 's/\r//' mobile/gradlew mobile/gradle/wrapper/gradle-wrapper.properties
+
+      - name: Run unit tests
+        run: |
+          cd mobile
+          echo "sdk.dir=$ANDROID_HOME" > local.properties
+          ./gradlew testDebugUnitTest --no-daemon
+
+      - name: Upload Android test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-test-reports
+          path: |
+            mobile/app/build/reports/tests/testDebugUnitTest/
+            mobile/app/build/test-results/testDebugUnitTest/
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [test, frontend-test]
+    needs: [test, frontend-test, android-test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - name: Deploy via SSH

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,9 +51,9 @@ jobs:
           DB_PASSWORD: testpass
           DB_HOST: localhost
           DB_PORT: 5432
-          TEST_OUTPUT_DIR: ../test-reports/backend
+          TEST_OUTPUT_DIR: test-reports
         run: |
-          mkdir -p test-reports/backend
+          mkdir -p backend/test-reports
           cd backend
           python manage.py migrate --noinput
           python manage.py test accounts forum help_requests \
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: backend-test-reports
-          path: test-reports/backend/
+          path: backend/test-reports/
 
   frontend-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,9 +51,9 @@ jobs:
           DB_PASSWORD: testpass
           DB_HOST: localhost
           DB_PORT: 5432
-          TEST_OUTPUT_DIR: test-reports
+          TEST_OUTPUT_DIR: ${{ github.workspace }}/test-reports/backend
         run: |
-          mkdir -p backend/test-reports
+          mkdir -p ${{ github.workspace }}/test-reports/backend
           cd backend
           python manage.py migrate --noinput
           python manage.py test accounts forum help_requests \
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: backend-test-reports
-          path: backend/test-reports/
+          path: test-reports/backend/
 
   frontend-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,13 +51,13 @@ jobs:
           DB_PASSWORD: testpass
           DB_HOST: localhost
           DB_PORT: 5432
+          TEST_OUTPUT_DIR: ../test-reports/backend
         run: |
           mkdir -p test-reports/backend
           cd backend
           python manage.py migrate --noinput
           python manage.py test accounts forum help_requests \
             --testrunner=xmlrunner.extra.djangotestrunner.XMLTestRunner \
-            --output-file=../test-reports/backend/results.xml \
             --verbosity=2
 
       - name: Upload backend test reports
@@ -116,9 +116,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Write google-services.json
-        env:
-          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
-        run: echo "$GOOGLE_SERVICES_JSON" > mobile/app/google-services.json
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' | base64 -d > mobile/app/google-services.json
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,9 +120,6 @@ jobs:
       - name: Write google-services.json
         run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > mobile/app/google-services.json
 
-      - name: Fix gradlew line endings
-        run: sed -i 's/\r//' mobile/gradlew mobile/gradle/wrapper/gradle-wrapper.properties
-
       - name: Run unit tests
         run: |
           cd mobile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
 
     services:
       postgres:
@@ -62,9 +65,13 @@ jobs:
           # xmlrunner writes TEST-*.xml into cwd; move them to the expected location
           mv TEST-*.xml ${{ github.workspace }}/test-reports/backend/ 2>/dev/null || true
 
-      - name: Debug report paths
+      - name: Publish backend test report
         if: always()
-        run: ls -la ${{ github.workspace }}/test-reports/backend/ || echo "Directory not found"
+        uses: dorny/test-reporter@v1
+        with:
+          name: Backend Test Results
+          path: test-reports/backend/TEST-*.xml
+          reporter: java-junit
 
       - name: Upload backend test reports
         if: always()
@@ -75,6 +82,9 @@ jobs:
 
   frontend-test:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -102,6 +112,14 @@ jobs:
             --reporters=default \
             --reporters=jest-junit
 
+      - name: Publish frontend test report
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Frontend Test Results
+          path: test-reports/frontend/results.xml
+          reporter: java-junit
+
       - name: Upload frontend test reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -111,6 +129,9 @@ jobs:
 
   android-test:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -129,6 +150,14 @@ jobs:
           cd mobile
           echo "sdk.dir=$ANDROID_HOME" > local.properties
           ./gradlew testDebugUnitTest --no-daemon
+
+      - name: Publish Android test report
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: Android Test Results
+          path: mobile/app/build/test-results/testDebugUnitTest/*.xml
+          reporter: java-junit
 
       - name: Upload Android test reports
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           cd backend
           pip install -r requirements.txt
-          pip install unittest-xml-reporting pytest pytest-html pytest-django
+          pip install unittest-xml-reporting
 
       - name: Run tests
         env:
@@ -51,16 +51,14 @@ jobs:
           DB_PASSWORD: testpass
           DB_HOST: localhost
           DB_PORT: 5432
-          DJANGO_SETTINGS_MODULE: backend.settings
         run: |
           mkdir -p test-reports/backend
           cd backend
           python manage.py migrate --noinput
-          pytest accounts forum help_requests \
-            --junitxml=../test-reports/backend/results.xml \
-            --html=../test-reports/backend/report.html \
-            --self-contained-html \
-            -p no:cacheprovider
+          python manage.py test accounts forum help_requests \
+            --testrunner=xmlrunner.extra.djangotestrunner.XMLTestRunner \
+            --output-file=../test-reports/backend/results.xml \
+            --verbosity=2
 
       - name: Upload backend test reports
         if: always()
@@ -118,7 +116,9 @@ jobs:
           distribution: 'temurin'
 
       - name: Write google-services.json
-        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > mobile/app/google-services.json
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: echo "$GOOGLE_SERVICES_JSON" > mobile/app/google-services.json
 
       - name: Run unit tests
         run: |

--- a/README.md
+++ b/README.md
@@ -176,14 +176,16 @@ npm test
 
 ### Android (JUnit 4 — 51 tests)
 
-**macOS / Linux:**
+Requires Android Studio installed (sets up JDK and `ANDROID_HOME` automatically).
+
+**macOS / Linux / WSL:**
 ```bash
 cd mobile
 echo "sdk.dir=$ANDROID_HOME" > local.properties
 ./gradlew testDebugUnitTest --no-daemon
 ```
 
-**Windows (PowerShell):**
+**Windows — without Android Studio (Docker required):**
 ```powershell
 docker run --rm `
   -v "C:/path/to/repo/mobile:/app" `
@@ -191,6 +193,7 @@ docker run --rm `
   mingc/android-build-box:latest `
   bash -c "echo 'sdk.dir=`$ANDROID_HOME' > local.properties && ./gradlew testDebugUnitTest --no-daemon"
 ```
+Replace `C:/path/to/repo` with the actual path to your clone.
 
 ---
 


### PR DESCRIPTION
## Description

Re-added Android unit tests (JUnit 4) with fixes for `gradlew` line endings and JVM opts that previously caused failures on CI. Updated the CI workflow to run all three test suites on every PR to main and upload HTML/XML test reports as downloadable artifacts.



## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update


