### PR TITLE
fix: default debug BASE_URL to emulator localhost

### DIFF
--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -11,7 +11,7 @@ val localProps = Properties().apply {
     val f = rootProject.file("local.properties")
     if (f.exists()) load(f.inputStream())
 }
-val localBaseUrl: String = localProps.getProperty("BASE_URL") ?: "https://emergencyhub.duckdns.org/api/"
+val localBaseUrl: String = localProps.getProperty("BASE_URL") ?: "http://10.0.2.2:8000/"
 
 android {
     namespace = "com.bounswe2026group8.emergencyhub"


### PR DESCRIPTION
## Description
Debug builds were reading `BASE_URL` from `local.properties` with a fallback to the production URL. Developers without a pre-configured `local.properties` would silently connect to the production backend during local development. Changed the fallback to `http://10.0.2.2:8000/` (Android emulator's address for localhost).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] The commit message follows our guidelines.
- [x] My changes generate no new warnings or errors.
