### PR TITLE
test: add RTL frontend tests for auth, forum, help requests, and profile pages

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+playwright-report/
+test-results/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/src/pages/ForumPage.test.jsx
+++ b/frontend/src/pages/ForumPage.test.jsx
@@ -1,0 +1,194 @@
+/**
+ * Integration tests for ForumPage.
+ *
+ * Covers: post list rendering, forum type tab filters, empty states,
+ * vote toggle behavior, and new post button visibility.
+ */
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ForumPage from './ForumPage';
+import { AuthProvider } from '../context/AuthContext';
+
+jest.mock('react-i18next', () => {
+  const en = require('../locales/en.json');
+  function t(key, opts) {
+    const parts = key.split('.');
+    let val = en;
+    for (const p of parts) {
+      if (val == null || typeof val !== 'object') return key;
+      val = val[p];
+    }
+    if (typeof val !== 'string') return key;
+    if (!opts) return val;
+    return val.replace(/\{\{(\w+)\}\}/g, (_, k) =>
+      opts[k] !== undefined ? String(opts[k]) : `{{${k}}}`
+    );
+  }
+  return { useTranslation: () => ({ t, i18n: { changeLanguage: jest.fn(), language: 'en' } }) };
+});
+
+jest.mock('../services/api');
+import * as api from '../services/api';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const STANDARD_USER = {
+  id: 1,
+  email: 'u@example.com',
+  role: 'STANDARD',
+  hub: { id: 2, name: 'Istanbul', slug: 'istanbul' },
+};
+const USER_NO_HUB = { ...STANDARD_USER, hub: null };
+
+const makePost = (overrides = {}) => ({
+  id: 1,
+  title: 'Test Post',
+  content: 'Content here',
+  forum_type: 'GLOBAL',
+  hub_name: 'Istanbul',
+  upvote_count: 0,
+  downvote_count: 0,
+  comment_count: 0,
+  user_vote: null,
+  user_has_reposted: false,
+  repost_count: 0,
+  reposted_from: null,
+  image_urls: [],
+  created_at: '2026-01-01T00:00:00Z',
+  author: { id: 99, full_name: 'Other User', role: 'STANDARD', email: 'o@example.com', profile: null },
+  ...overrides,
+});
+
+/**
+ * Renders ForumPage inside MemoryRouter + AuthProvider.
+ * Pass null for userData to render as unauthenticated.
+ */
+async function renderForum(userData = STANDARD_USER, initialTab = null) {
+  if (userData) {
+    localStorage.setItem('token', 'test-token');
+    api.getMe.mockResolvedValue({ ok: true, status: 200, data: userData });
+  }
+  const entry = initialTab ? `/?tab=${initialTab}` : '/';
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={[entry]}>
+        <AuthProvider>
+          <ForumPage />
+        </AuthProvider>
+      </MemoryRouter>
+    );
+  });
+  await waitFor(() => {
+    expect(screen.queryByText(/loading posts/i)).not.toBeInTheDocument();
+  });
+}
+
+describe('ForumPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockNavigate.mockClear();
+    api.getMe.mockResolvedValue({ ok: false, status: 401, data: null });
+    api.getHubs.mockResolvedValue({ ok: true, data: [] });
+    api.vote.mockResolvedValue({ ok: true });
+    api.getPosts.mockResolvedValue({ ok: true, data: [] });
+  });
+
+  // ── Rendering ────────────────────────────────────────────────────────────────
+
+  it('renders post titles from API', async () => {
+    api.getPosts.mockResolvedValue({ ok: true, data: [makePost()] });
+    await renderForum();
+    expect(screen.getByText('Test Post')).toBeInTheDocument();
+  });
+
+  it('shows no-global empty state when GLOBAL tab has no posts', async () => {
+    await renderForum();
+    expect(screen.getByText(/no global posts yet/i)).toBeInTheDocument();
+  });
+
+  it('shows select-hub empty state for STANDARD tab when user has no hub', async () => {
+    await renderForum(USER_NO_HUB, 'STANDARD');
+    expect(screen.getByText(/select a hub to see/i)).toBeInTheDocument();
+    expect(api.getPosts).not.toHaveBeenCalledWith(
+      expect.objectContaining({ forumType: 'STANDARD' })
+    );
+  });
+
+  // ── Filters ──────────────────────────────────────────────────────────────────
+
+  it('calls getPosts with STANDARD forumType and hub id after tab switch', async () => {
+    await renderForum();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /standard/i }));
+
+    await waitFor(() => {
+      expect(api.getPosts).toHaveBeenCalledWith({ hub: 2, forumType: 'STANDARD' });
+    });
+  });
+
+  // ── Voting ───────────────────────────────────────────────────────────────────
+
+  it('upvote increments count and adds vote-active class', async () => {
+    api.getPosts.mockResolvedValue({ ok: true, data: [makePost({ upvote_count: 3 })] });
+    await renderForum();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTitle('Upvote'));
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Upvote')).toHaveTextContent('4');
+      expect(screen.getByTitle('Upvote')).toHaveClass('vote-active');
+    });
+    expect(api.vote).toHaveBeenCalledWith(1, 'UP');
+  });
+
+  it('toggling same vote twice removes it', async () => {
+    api.getPosts.mockResolvedValue({ ok: true, data: [makePost({ upvote_count: 3 })] });
+    await renderForum();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTitle('Upvote'));
+    await waitFor(() => expect(screen.getByTitle('Upvote')).toHaveTextContent('4'));
+
+    await user.click(screen.getByTitle('Upvote'));
+    await waitFor(() => {
+      expect(screen.getByTitle('Upvote')).toHaveTextContent('3');
+      expect(screen.getByTitle('Upvote')).not.toHaveClass('vote-active');
+    });
+  });
+
+  it('switching UP to DOWN adjusts both counts', async () => {
+    api.getPosts.mockResolvedValue({
+      ok: true,
+      data: [makePost({ upvote_count: 3, downvote_count: 1, user_vote: 'UP' })],
+    });
+    await renderForum();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTitle('Downvote'));
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Upvote')).toHaveTextContent('2');
+      expect(screen.getByTitle('Downvote')).toHaveTextContent('2');
+    });
+  });
+
+  // ── Authorization ─────────────────────────────────────────────────────────────
+
+  it('shows + New Post button for authenticated user', async () => {
+    await renderForum();
+    expect(screen.getByRole('button', { name: /new post/i })).toBeInTheDocument();
+  });
+
+  it('hides + New Post button for unauthenticated user', async () => {
+    await renderForum(null);
+    expect(screen.queryByRole('button', { name: /new post/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/HelpRequestCreatePage.test.jsx
+++ b/frontend/src/pages/HelpRequestCreatePage.test.jsx
@@ -1,0 +1,162 @@
+/**
+ * Integration tests for HelpRequestCreatePage.
+ *
+ * Covers: form rendering, client-side validation (empty title, empty description),
+ * successful submission payload, navigation on success, and global error display.
+ */
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import HelpRequestCreatePage from './HelpRequestCreatePage';
+import { AuthProvider } from '../context/AuthContext';
+
+jest.mock('react-i18next', () => {
+  const en = require('../locales/en.json');
+  function t(key, opts) {
+    const parts = key.split('.');
+    let val = en;
+    for (const p of parts) {
+      if (val == null || typeof val !== 'object') return key;
+      val = val[p];
+    }
+    if (typeof val !== 'string') return key;
+    if (!opts) return val;
+    return val.replace(/\{\{(\w+)\}\}/g, (_, k) =>
+      opts[k] !== undefined ? String(opts[k]) : `{{${k}}}`
+    );
+  }
+  return { useTranslation: () => ({ t, i18n: { changeLanguage: jest.fn(), language: 'en' } }) };
+});
+
+jest.mock('../services/api');
+import * as api from '../services/api';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const STANDARD_USER = {
+  id: 1,
+  email: 'u@example.com',
+  full_name: 'Alice',
+  role: 'STANDARD',
+  hub: { id: 2, name: 'Istanbul', slug: 'istanbul' },
+};
+
+/**
+ * Renders HelpRequestCreatePage as an authenticated user.
+ * Waits for the submit button since the page returns null until auth resolves.
+ */
+async function renderCreate(userData = STANDARD_USER) {
+  localStorage.setItem('token', 'test-token');
+  api.getMe.mockResolvedValue({ ok: true, status: 200, data: userData });
+  await act(async () => {
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <HelpRequestCreatePage />
+        </AuthProvider>
+      </MemoryRouter>
+    );
+  });
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /submit request/i })).toBeInTheDocument();
+  });
+}
+
+describe('HelpRequestCreatePage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockNavigate.mockClear();
+    api.getMe.mockResolvedValue({ ok: false, status: 401, data: null });
+    api.getHubs.mockResolvedValue({ ok: true, data: [] });
+    api.createHelpRequest.mockClear();
+  });
+
+  // ── Rendering ────────────────────────────────────────────────────────────────
+
+  it('renders form fields', async () => {
+    await renderCreate();
+    expect(screen.getByLabelText(/^title$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^description$/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /submit request/i })).toBeInTheDocument();
+  });
+
+  // ── Validation ───────────────────────────────────────────────────────────────
+
+  it('shows error when title is empty', async () => {
+    await renderCreate();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /submit request/i }));
+
+    expect(screen.getByText('Title is required.')).toBeInTheDocument();
+    expect(api.createHelpRequest).not.toHaveBeenCalled();
+  });
+
+  it('shows error when description is empty', async () => {
+    await renderCreate();
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^title$/i), 'Need help');
+    await user.click(screen.getByRole('button', { name: /submit request/i }));
+
+    expect(screen.getByText('Description is required.')).toBeInTheDocument();
+    expect(api.createHelpRequest).not.toHaveBeenCalled();
+  });
+
+  // ── Submission ───────────────────────────────────────────────────────────────
+
+  it('calls createHelpRequest with correct payload', async () => {
+    api.createHelpRequest.mockResolvedValue({ ok: true, data: { id: 5 } });
+    await renderCreate();
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^title$/i), 'Need help');
+    await user.type(screen.getByLabelText(/^description$/i), 'Urgent');
+    await user.click(screen.getByRole('button', { name: /submit request/i }));
+
+    await waitFor(() => {
+      expect(api.createHelpRequest).toHaveBeenCalledWith({
+        title: 'Need help',
+        description: 'Urgent',
+        category: 'MEDICAL',
+        urgency: 'MEDIUM',
+      });
+    });
+  });
+
+  it('navigates to detail page on successful creation', async () => {
+    api.createHelpRequest.mockResolvedValue({ ok: true, data: { id: 5 } });
+    await renderCreate();
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^title$/i), 'Need help');
+    await user.type(screen.getByLabelText(/^description$/i), 'Urgent');
+    await user.click(screen.getByRole('button', { name: /submit request/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/help-requests/5');
+    });
+  });
+
+  it('shows global error on failed creation', async () => {
+    api.createHelpRequest.mockResolvedValue({
+      ok: false,
+      data: { detail: 'Server error' },
+    });
+    await renderCreate();
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^title$/i), 'Need help');
+    await user.type(screen.getByLabelText(/^description$/i), 'Urgent');
+    await user.click(screen.getByRole('button', { name: /submit request/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/HelpRequestsPage.test.jsx
+++ b/frontend/src/pages/HelpRequestsPage.test.jsx
@@ -14,6 +14,24 @@ import { MemoryRouter } from 'react-router-dom';
 import HelpRequestsPage from './HelpRequestsPage';
 import { AuthProvider } from '../context/AuthContext';
 
+jest.mock('react-i18next', () => {
+  const en = require('../locales/en.json');
+  function t(key, opts) {
+    const parts = key.split('.');
+    let val = en;
+    for (const p of parts) {
+      if (val == null || typeof val !== 'object') return key;
+      val = val[p];
+    }
+    if (typeof val !== 'string') return key;
+    if (!opts) return val;
+    return val.replace(/\{\{(\w+)\}\}/g, (_, k) =>
+      opts[k] !== undefined ? String(opts[k]) : `{{${k}}}`
+    );
+  }
+  return { useTranslation: () => ({ t, i18n: { changeLanguage: jest.fn(), language: 'en' } }) };
+});
+
 jest.mock('../services/api');
 import * as api from '../services/api';
 

--- a/frontend/src/pages/PostDetailPage.test.jsx
+++ b/frontend/src/pages/PostDetailPage.test.jsx
@@ -1,0 +1,272 @@
+/**
+ * Integration tests for PostDetailPage.
+ *
+ * Covers: post and comment rendering, vote toggle behavior,
+ * report modal flow, and comment submission.
+ */
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import PostDetailPage from './PostDetailPage';
+import { AuthProvider } from '../context/AuthContext';
+
+jest.mock('react-i18next', () => {
+  const en = require('../locales/en.json');
+  function t(key, opts) {
+    const parts = key.split('.');
+    let val = en;
+    for (const p of parts) {
+      if (val == null || typeof val !== 'object') return key;
+      val = val[p];
+    }
+    if (typeof val !== 'string') return key;
+    if (!opts) return val;
+    return val.replace(/\{\{(\w+)\}\}/g, (_, k) =>
+      opts[k] !== undefined ? String(opts[k]) : `{{${k}}}`
+    );
+  }
+  return { useTranslation: () => ({ t, i18n: { changeLanguage: jest.fn(), language: 'en' } }) };
+});
+
+jest.mock('../services/api');
+import * as api from '../services/api';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ id: '1' }),
+}));
+
+/** Authenticated viewer — different id from the post author (99). */
+const VIEWER = {
+  id: 1,
+  email: 'viewer@example.com',
+  role: 'STANDARD',
+  hub: { id: 2, name: 'Istanbul', slug: 'istanbul' },
+};
+
+const makePost = (overrides = {}) => ({
+  id: 1,
+  title: 'Forum Post',
+  content: 'Post body text.',
+  forum_type: 'GLOBAL',
+  hub_name: 'Istanbul',
+  upvote_count: 5,
+  downvote_count: 2,
+  comment_count: 0,
+  user_vote: null,
+  user_has_reposted: false,
+  repost_count: 0,
+  reposted_from: null,
+  image_urls: [],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  author: { id: 99, full_name: 'Author Name', role: 'STANDARD', email: 'author@example.com', profile: null },
+  ...overrides,
+});
+
+const makeComment = (overrides = {}) => ({
+  id: 10,
+  content: 'Nice post!',
+  created_at: '2026-01-02T00:00:00Z',
+  author: { id: 99, full_name: 'Commenter', role: 'STANDARD', profile: null },
+  ...overrides,
+});
+
+async function renderPage(userData = VIEWER) {
+  localStorage.setItem('token', 'test-token');
+  api.getMe.mockResolvedValue({ ok: true, status: 200, data: userData });
+  await act(async () => {
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <PostDetailPage />
+        </AuthProvider>
+      </MemoryRouter>
+    );
+  });
+  await waitFor(() => {
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+  });
+}
+
+describe('PostDetailPage — rendering', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockNavigate.mockClear();
+    api.getMe.mockResolvedValue({ ok: false, status: 401, data: null });
+    api.getHubs.mockResolvedValue({ ok: true, data: [] });
+    api.getPost.mockResolvedValue({ ok: true, data: makePost() });
+    api.getComments.mockResolvedValue({ ok: true, data: [] });
+    api.vote.mockResolvedValue({ ok: true });
+    api.reportPost.mockResolvedValue({ ok: true, data: {} });
+    api.createComment.mockResolvedValue({
+      ok: true,
+      data: makeComment({ id: 20, content: 'My comment' }),
+    });
+  });
+
+  it('renders post title and content', async () => {
+    await renderPage();
+    expect(screen.getByText('Forum Post')).toBeInTheDocument();
+    expect(screen.getByText('Post body text.')).toBeInTheDocument();
+  });
+
+  it('shows empty comment state when no comments', async () => {
+    await renderPage();
+    expect(screen.getByText(/no comments yet/i)).toBeInTheDocument();
+  });
+
+  it('renders comment list when comments exist', async () => {
+    api.getComments.mockResolvedValue({ ok: true, data: [makeComment()] });
+    await renderPage();
+    expect(screen.getByText('Nice post!')).toBeInTheDocument();
+  });
+});
+
+describe('PostDetailPage — voting', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockNavigate.mockClear();
+    api.getMe.mockResolvedValue({ ok: false, status: 401, data: null });
+    api.getHubs.mockResolvedValue({ ok: true, data: [] });
+    api.getPost.mockResolvedValue({ ok: true, data: makePost() });
+    api.getComments.mockResolvedValue({ ok: true, data: [] });
+    api.vote.mockResolvedValue({ ok: true });
+    api.reportPost.mockResolvedValue({ ok: true, data: {} });
+    api.createComment.mockResolvedValue({
+      ok: true,
+      data: makeComment({ id: 20, content: 'My comment' }),
+    });
+  });
+
+  it('upvote increments count and adds vote-active class', async () => {
+    await renderPage();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTitle('Upvote'));
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Upvote')).toHaveTextContent('6');
+      expect(screen.getByTitle('Upvote')).toHaveClass('vote-active');
+    });
+    expect(api.vote).toHaveBeenCalledWith('1', 'UP');
+  });
+
+  it('toggling same vote twice removes it', async () => {
+    await renderPage();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTitle('Upvote'));
+    await waitFor(() => expect(screen.getByTitle('Upvote')).toHaveTextContent('6'));
+
+    await user.click(screen.getByTitle('Upvote'));
+    await waitFor(() => {
+      expect(screen.getByTitle('Upvote')).toHaveTextContent('5');
+      expect(screen.getByTitle('Upvote')).not.toHaveClass('vote-active');
+    });
+  });
+
+  it('switching UP to DOWN adjusts both counts', async () => {
+    api.getPost.mockResolvedValue({
+      ok: true,
+      data: makePost({ upvote_count: 5, downvote_count: 2, user_vote: 'UP' }),
+    });
+    await renderPage();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTitle('Downvote'));
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Upvote')).toHaveTextContent('4');
+      expect(screen.getByTitle('Downvote')).toHaveTextContent('3');
+    });
+  });
+});
+
+describe('PostDetailPage — report modal', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockNavigate.mockClear();
+    api.getMe.mockResolvedValue({ ok: false, status: 401, data: null });
+    api.getHubs.mockResolvedValue({ ok: true, data: [] });
+    api.getPost.mockResolvedValue({ ok: true, data: makePost() });
+    api.getComments.mockResolvedValue({ ok: true, data: [] });
+    api.vote.mockResolvedValue({ ok: true });
+    api.reportPost.mockResolvedValue({ ok: true, data: {} });
+    api.createComment.mockResolvedValue({
+      ok: true,
+      data: makeComment({ id: 20, content: 'My comment' }),
+    });
+  });
+
+  it('report button not visible when user is the post author', async () => {
+    // Author id is 99; render as user id=99 (same as author)
+    await renderPage({ ...VIEWER, id: 99 });
+    expect(screen.queryByRole('button', { name: /report/i })).not.toBeInTheDocument();
+  });
+
+  it('report modal opens on Report button click', async () => {
+    await renderPage();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /report/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/report this post/i)).toBeInTheDocument();
+    });
+  });
+
+  it('report modal submits with selected reason', async () => {
+    await renderPage();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /report/i }));
+    await waitFor(() => expect(screen.getByLabelText(/reason/i)).toBeInTheDocument());
+
+    await user.selectOptions(screen.getByLabelText(/reason/i), 'ABUSE');
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(api.reportPost).toHaveBeenCalledWith('1', 'ABUSE');
+    });
+  });
+});
+
+describe('PostDetailPage — comments', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockNavigate.mockClear();
+    api.getMe.mockResolvedValue({ ok: false, status: 401, data: null });
+    api.getHubs.mockResolvedValue({ ok: true, data: [] });
+    api.getPost.mockResolvedValue({ ok: true, data: makePost() });
+    api.getComments.mockResolvedValue({ ok: true, data: [] });
+    api.vote.mockResolvedValue({ ok: true });
+    api.reportPost.mockResolvedValue({ ok: true, data: {} });
+    api.createComment.mockResolvedValue({
+      ok: true,
+      data: makeComment({ id: 20, content: 'My comment' }),
+    });
+  });
+
+  it('comment form is shown for authenticated user', async () => {
+    await renderPage();
+    expect(screen.getByPlaceholderText(/write a comment/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /post comment/i })).toBeInTheDocument();
+  });
+
+  it('submitting a comment calls createComment and appends the text', async () => {
+    await renderPage();
+
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText(/write a comment/i), 'My comment');
+    await user.click(screen.getByRole('button', { name: /post comment/i }));
+
+    await waitFor(() => {
+      expect(api.createComment).toHaveBeenCalledWith('1', 'My comment');
+    });
+    expect(screen.getByText('My comment')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ProfilePage.test.jsx
+++ b/frontend/src/pages/ProfilePage.test.jsx
@@ -1,0 +1,193 @@
+/**
+ * Integration tests for ProfilePage.
+ *
+ * Covers: user identity rendering, personal information section, bio placeholder
+ * and populated state, resources accordion (empty/populated/add form), and
+ * role-conditional expertise accordion (STANDARD vs EXPERT).
+ */
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ProfilePage from './ProfilePage';
+import { AuthProvider } from '../context/AuthContext';
+
+jest.mock('react-i18next', () => {
+  const en = require('../locales/en.json');
+  function t(key, opts) {
+    const parts = key.split('.');
+    let val = en;
+    for (const p of parts) {
+      if (val == null || typeof val !== 'object') return key;
+      val = val[p];
+    }
+    if (typeof val !== 'string') return key;
+    if (!opts) return val;
+    return val.replace(/\{\{(\w+)\}\}/g, (_, k) =>
+      opts[k] !== undefined ? String(opts[k]) : `{{${k}}}`
+    );
+  }
+  return { useTranslation: () => ({ t, i18n: { changeLanguage: jest.fn(), language: 'en' } }) };
+});
+
+jest.mock('../services/api');
+import * as api from '../services/api';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => jest.fn(),
+}));
+
+const STANDARD_USER = {
+  id: 1,
+  email: 'user@example.com',
+  full_name: 'Alice Smith',
+  role: 'STANDARD',
+  hub: { id: 2, name: 'Istanbul', slug: 'istanbul' },
+};
+const EXPERT_USER = { ...STANDARD_USER, role: 'EXPERT' };
+
+const EMPTY_PROFILE = {
+  phone_number: '',
+  blood_type: '',
+  emergency_contact: '',
+  emergency_contact_phone: '',
+  preferred_language: '',
+  has_disability: false,
+  availability_status: 'SAFE',
+  special_needs: '',
+  bio: '',
+};
+
+const makeResource = (overrides = {}) => ({
+  id: 1,
+  name: 'Generator',
+  category: 'Power',
+  quantity: 2,
+  condition: true,
+  ...overrides,
+});
+
+/**
+ * Renders ProfilePage as an authenticated user.
+ * Waits for both the page title and the user's full name to confirm auth resolved.
+ */
+async function renderProfile(userData = STANDARD_USER) {
+  localStorage.setItem('token', 'test-token');
+  api.getMe.mockResolvedValue({ ok: true, status: 200, data: userData });
+  await act(async () => {
+    render(
+      <MemoryRouter>
+        <AuthProvider>
+          <ProfilePage />
+        </AuthProvider>
+      </MemoryRouter>
+    );
+  });
+  await waitFor(() => {
+    expect(screen.getByText('Your Profile')).toBeInTheDocument();
+    expect(screen.getByText(userData.full_name)).toBeInTheDocument();
+  });
+}
+
+describe('ProfilePage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    api.getMe.mockResolvedValue({ ok: false, status: 401, data: null });
+    api.getHubs.mockResolvedValue({ ok: true, data: [] });
+    api.getProfile.mockResolvedValue({ ok: true, data: EMPTY_PROFILE });
+    api.getResources.mockResolvedValue({ ok: true, data: [] });
+    api.getExpertiseFields.mockResolvedValue({ ok: true, data: [] });
+    api.getExpertiseCategories.mockResolvedValue({ ok: true, data: [] });
+  });
+
+  // ── Identity ─────────────────────────────────────────────────────────────────
+
+  it('renders user name and email', async () => {
+    await renderProfile();
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('user@example.com')).toBeInTheDocument();
+  });
+
+  // ── Personal Information ──────────────────────────────────────────────────────
+
+  it('renders Personal Information section', async () => {
+    await renderProfile();
+    expect(screen.getByText('Personal Information')).toBeInTheDocument();
+  });
+
+  it('shows bio placeholder when bio is empty', async () => {
+    await renderProfile();
+    expect(screen.getByText('Tell others about yourself…')).toBeInTheDocument();
+  });
+
+  it('shows bio text when profile returns a bio', async () => {
+    api.getProfile.mockResolvedValue({ ok: true, data: { ...EMPTY_PROFILE, bio: 'Software engineer' } });
+    await renderProfile();
+    await waitFor(() => {
+      expect(screen.getByText('Software engineer')).toBeInTheDocument();
+    });
+  });
+
+  // ── Resources accordion ───────────────────────────────────────────────────────
+
+  it('Resources accordion header is always visible', async () => {
+    await renderProfile();
+    expect(screen.getByRole('button', { name: /resources/i })).toBeInTheDocument();
+  });
+
+  it('shows empty resources message after opening accordion', async () => {
+    await renderProfile();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /^📦 Resources$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No resources added yet.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows resource name after opening accordion', async () => {
+    api.getResources.mockResolvedValue({ ok: true, data: [makeResource()] });
+    await renderProfile();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /^📦 Resources/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Generator')).toBeInTheDocument();
+    });
+  });
+
+  // ── Expertise accordion (role-conditional) ────────────────────────────────────
+
+  it('expertise accordion is NOT rendered for standard user', async () => {
+    await renderProfile(STANDARD_USER);
+    expect(
+      screen.queryByRole('button', { name: /expertise fields/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('expertise accordion IS rendered for expert user', async () => {
+    await renderProfile(EXPERT_USER);
+    expect(
+      screen.getByRole('button', { name: /expertise fields/i })
+    ).toBeInTheDocument();
+  });
+
+  // ── Resource add form ─────────────────────────────────────────────────────────
+
+  it('resource add form appears after opening accordion and clicking Add Resource', async () => {
+    await renderProfile();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /^📦 Resources/i }));
+    await user.click(await screen.findByRole('button', { name: /add resource/i }));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/e\.g\. Generator/i)).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/e\.g\. Power/i)).toBeInTheDocument();
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/SignInPage.test.jsx
+++ b/frontend/src/pages/SignInPage.test.jsx
@@ -11,6 +11,20 @@ import { MemoryRouter } from 'react-router-dom';
 import SignInPage from './SignInPage';
 import { AuthProvider } from '../context/AuthContext';
 
+jest.mock('react-i18next', () => {
+  const en = require('../locales/en.json');
+  function t(key) {
+    const parts = key.split('.');
+    let val = en;
+    for (const p of parts) {
+      if (val == null || typeof val !== 'object') return key;
+      val = val[p];
+    }
+    return typeof val === 'string' ? val : key;
+  }
+  return { useTranslation: () => ({ t, i18n: { changeLanguage: jest.fn(), language: 'en' } }) };
+});
+
 jest.mock('../services/api');
 import * as api from '../services/api';
 

--- a/frontend/src/pages/SignUpPage.test.jsx
+++ b/frontend/src/pages/SignUpPage.test.jsx
@@ -1,0 +1,178 @@
+/**
+ * Unit and integration tests for SignUpPage.
+ *
+ * Covers: form rendering, client-side validation (passwords mismatch, too short,
+ * missing full name), successful registration, and backend error display
+ * (section 6.2 of the test plan).
+ */
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import SignUpPage from './SignUpPage';
+import { AuthProvider } from '../context/AuthContext';
+
+jest.mock('react-i18next', () => {
+  const en = require('../locales/en.json');
+  function t(key) {
+    const parts = key.split('.');
+    let val = en;
+    for (const p of parts) {
+      if (val == null || typeof val !== 'object') return key;
+      val = val[p];
+    }
+    return typeof val === 'string' ? val : key;
+  }
+  return { useTranslation: () => ({ t, i18n: { changeLanguage: jest.fn(), language: 'en' } }) };
+});
+
+jest.mock('../services/api');
+import * as api from '../services/api';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+function renderSignUp() {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <SignUpPage />
+      </AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('SignUpPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockNavigate.mockClear();
+    api.getMe.mockResolvedValue({ ok: false, status: 401, data: null });
+    api.getHubs.mockResolvedValue({ ok: true, data: [] });
+    api.getExpertiseCategories.mockResolvedValue({ ok: true, data: [] });
+    api.register.mockClear();
+  });
+
+  // ── Rendering ────────────────────────────────────────────────────────────────
+
+  it('renders the registration form fields', async () => {
+    await act(async () => { renderSignUp(); });
+    expect(screen.getByLabelText(/full name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Password', { selector: 'input' })).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+  });
+
+  // ── Validation ───────────────────────────────────────────────────────────────
+
+  it('shows error when passwords do not match', async () => {
+    const user = userEvent.setup();
+    await act(async () => { renderSignUp(); });
+
+    await user.type(screen.getByLabelText(/full name/i), 'Alice Smith');
+    await user.type(screen.getByLabelText(/email/i), 'alice@example.com');
+    await user.type(screen.getByLabelText('Password', { selector: 'input' }), 'Abc1234!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'Different1!');
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+
+    expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument();
+    expect(api.register).not.toHaveBeenCalled();
+  });
+
+  it('shows error when password is too short', async () => {
+    const user = userEvent.setup();
+    await act(async () => { renderSignUp(); });
+
+    await user.type(screen.getByLabelText(/full name/i), 'Alice Smith');
+    await user.type(screen.getByLabelText(/email/i), 'alice@example.com');
+    await user.type(screen.getByLabelText('Password', { selector: 'input' }), 'short');
+    await user.type(screen.getByLabelText(/confirm password/i), 'short');
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+
+    expect(screen.getByText(/password must be at least 8 characters/i)).toBeInTheDocument();
+    expect(api.register).not.toHaveBeenCalled();
+  });
+
+  it('shows error when full name is empty', async () => {
+    const user = userEvent.setup();
+    await act(async () => { renderSignUp(); });
+
+    await user.type(screen.getByLabelText(/email/i), 'alice@example.com');
+    await user.type(screen.getByLabelText('Password', { selector: 'input' }), 'Password1!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'Password1!');
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+
+    expect(screen.getByText(/full name is required/i)).toBeInTheDocument();
+    expect(api.register).not.toHaveBeenCalled();
+  });
+
+  // ── Successful registration ──────────────────────────────────────────────────
+
+  it('calls register API with correct payload', async () => {
+    api.register.mockResolvedValueOnce({ ok: true, data: {} });
+
+    const user = userEvent.setup();
+    await act(async () => { renderSignUp(); });
+
+    await user.type(screen.getByLabelText(/full name/i), 'Alice Smith');
+    await user.type(screen.getByLabelText(/email/i), 'alice@example.com');
+    await user.type(screen.getByLabelText('Password', { selector: 'input' }), 'Password1!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'Password1!');
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      expect(api.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          full_name: 'Alice Smith',
+          email: 'alice@example.com',
+          password: 'Password1!',
+          confirm_password: 'Password1!',
+          role: 'STANDARD',
+        })
+      );
+    });
+  });
+
+  it('shows success message on successful registration', async () => {
+    api.register.mockResolvedValueOnce({ ok: true, data: {} });
+
+    const user = userEvent.setup();
+    await act(async () => { renderSignUp(); });
+
+    await user.type(screen.getByLabelText(/full name/i), 'Alice Smith');
+    await user.type(screen.getByLabelText(/email/i), 'alice@example.com');
+    await user.type(screen.getByLabelText('Password', { selector: 'input' }), 'Password1!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'Password1!');
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/account created! redirecting to sign in/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── Failed registration ──────────────────────────────────────────────────────
+
+  it('shows backend error on failed registration', async () => {
+    api.register.mockResolvedValueOnce({
+      ok: false,
+      data: { message: 'Email already in use.' },
+    });
+
+    const user = userEvent.setup();
+    await act(async () => { renderSignUp(); });
+
+    await user.type(screen.getByLabelText(/full name/i), 'Alice Smith');
+    await user.type(screen.getByLabelText(/email/i), 'existing@example.com');
+    await user.type(screen.getByLabelText('Password', { selector: 'input' }), 'Password1!');
+    await user.type(screen.getByLabelText(/confirm password/i), 'Password1!');
+    await user.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/email already in use/i)).toBeInTheDocument();
+    });
+    // success banner must not appear — error path stays on the form
+    expect(screen.queryByText(/account created/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Adds React Testing Library integration tests for five frontend pages that previously had no coverage, and fixes `SignInPage.test.jsx` which was broken due to a missing `react-i18next` mock.

All tested components use `useTranslation()`, so each test file includes a `jest.mock('react-i18next', ...)` factory that resolves keys from `en.json` with `{{interpolation}}` support. Components are rendered inside `MemoryRouter + AuthProvider` with the `../services/api` module auto-mocked.

95 tests pass locally across 9 test suites with no regressions.

## Related Issues

Closes #286
Closes #287
Closes #288
Fixes #300 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] The commit message follows our guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [x] New and existing tests pass locally with my changes.
