### PR TITLE
test: add Playwright E2E tests for MVP acceptance scenarios

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -211,6 +211,21 @@ jobs:
           DB_PORT: 5432
         run: cd backend && python manage.py migrate --noinput
 
+      - name: Create test hub
+        env:
+          DJANGO_SECRET_KEY: ci-secret-key
+          DJANGO_DEBUG: 'True'
+          DB_NAME: testdb
+          DB_USER: testuser
+          DB_PASSWORD: testpass
+          DB_HOST: localhost
+          DB_PORT: 5432
+        run: |
+          cd backend && python manage.py shell -c "
+          from accounts.models import Hub
+          Hub.objects.get_or_create(name='Istanbul', slug='istanbul')
+          "
+
       - name: Start Django backend
         env:
           DJANGO_SECRET_KEY: ci-secret-key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Start Vite dev server
         env:
           VITE_API_BASE: http://127.0.0.1:8000
-        run: cd frontend && npm run dev &
+        run: cd frontend && npm run dev -- --host 127.0.0.1 &
 
       - name: Wait for servers
         run: npx wait-on tcp:127.0.0.1:8000 http://127.0.0.1:5173 --timeout 60000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,9 +168,96 @@ jobs:
             mobile/app/build/reports/tests/testDebugUnitTest/
             mobile/app/build/test-results/testDebugUnitTest/
 
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: testdb
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpass
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install backend dependencies
+        run: cd backend && pip install -r requirements.txt
+
+      - name: Run migrations
+        env:
+          DJANGO_SECRET_KEY: ci-secret-key
+          DJANGO_DEBUG: 'True'
+          DB_NAME: testdb
+          DB_USER: testuser
+          DB_PASSWORD: testpass
+          DB_HOST: localhost
+          DB_PORT: 5432
+        run: cd backend && python manage.py migrate --noinput
+
+      - name: Start Django backend
+        env:
+          DJANGO_SECRET_KEY: ci-secret-key
+          DJANGO_DEBUG: 'True'
+          DB_NAME: testdb
+          DB_USER: testuser
+          DB_PASSWORD: testpass
+          DB_HOST: localhost
+          DB_PORT: 5432
+        run: cd backend && python manage.py runserver 127.0.0.1:8000 &
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Install Playwright browsers
+        run: cd frontend && npx playwright install --with-deps chromium
+
+      - name: Start Vite dev server
+        env:
+          VITE_API_BASE: http://127.0.0.1:8000
+        run: cd frontend && npm run dev &
+
+      - name: Wait for servers
+        run: npx wait-on tcp:127.0.0.1:8000 http://127.0.0.1:5173 --timeout 60000
+
+      - name: Run Playwright tests
+        env:
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:5173
+        run: cd frontend && npm run e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+
   deploy:
     runs-on: ubuntu-latest
-    needs: [test, frontend-test, android-test]
+    needs: [test, frontend-test, android-test, e2e]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -248,6 +248,14 @@ jobs:
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:5173
         run: cd frontend && npm run e2e
 
+      - name: Publish E2E test report
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: E2E Test Results
+          path: frontend/test-results/results.xml
+          reporter: java-junit
+
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+playwright-report/
+test-results/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
+        "@types/node": "^22.0.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -3254,13 +3255,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/react": {
@@ -8212,9 +8213,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "@babel/preset-env": "^7.24.4",
         "@babel/preset-react": "^7.24.1",
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.52.0",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
@@ -34,7 +35,8 @@
         "globals": "^17.4.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "wait-on": "^8.0.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2116,6 +2118,60 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -2645,6 +2701,22 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@react-leaflet/core": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
@@ -2946,6 +3018,13 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -3428,6 +3507,18 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -4646,6 +4737,27 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/form-data": {
       "version": "4.0.5",
@@ -6233,6 +6345,25 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6685,6 +6816,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -6844,6 +6982,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -7147,6 +7295,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.13",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
@@ -7228,6 +7423,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/psl": {
@@ -7569,6 +7774,16 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -7958,8 +8173,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8245,6 +8459,26 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/wait-on": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
+      "integrity": "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.12.1",
+        "joi": "^18.0.1",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.2"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/walker": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "jest --config jest.config.cjs"
+    "test": "jest --config jest.config.cjs",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "i18next": "^26.0.6",
@@ -37,6 +38,8 @@
     "globals": "^17.4.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "@playwright/test": "^1.52.0",
+    "wait-on": "^8.0.1"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "vite": "^8.0.1",
     "@playwright/test": "^1.52.0",
+    "@types/node": "^22.0.0",
     "wait-on": "^8.0.1"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : 'html',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   timeout: 30_000,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI
-    ? [['github'], ['html', { open: 'never' }]]
+    ? [['github'], ['html', { open: 'never' }], ['junit', { outputFile: 'test-results/results.xml' }]]
     : 'html',
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:5173',

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * TC-AUTH-001: Register a new Expert user via the UI form.
+ * TC-AUTH-002: Login with valid/invalid credentials.
+ */
+
+import { test, expect } from '@playwright/test';
+import { createUser, loginAs, uniqueEmail, UserData } from './helpers/users';
+
+// ── TC-AUTH-001 ───────────────────────────────────────────────────────────────
+
+test.describe('TC-AUTH-001 — Expert registration via UI', () => {
+  test('registers a new Expert user and logs in successfully', async ({ page }) => {
+    const email = uniqueEmail('auth001');
+    const password = 'TestPass123!';
+
+    await page.goto('/signup');
+
+    await page.fill('#full_name', 'Expert User Test');
+    await page.fill('#email', email);
+    await page.fill('#password', password);
+    await page.fill('#confirm_password', password);
+
+    // Select Expert role — expertise category dropdown should appear
+    await page.selectOption('#role', 'EXPERT');
+    await expect(page.locator('#category_id')).toBeVisible();
+    await page.selectOption('#category_id', { index: 1 });
+
+    // Select first available hub if one exists
+    const hubSelect = page.locator('#hub_id');
+    const hubOptions = await hubSelect.locator('option').count();
+    if (hubOptions > 1) {
+      await hubSelect.selectOption({ index: 1 });
+    }
+
+    await page.click('button:has-text("Sign Up")');
+
+    // SignUpPage shows a success message then redirects to /signin after ~1500ms
+    await expect(page.getByText(/account created/i)).toBeVisible({ timeout: 15000 });
+    await page.waitForURL('**/signin', { timeout: 10000 });
+
+    // Login with new credentials
+    await loginAs(page, email, password);
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+});
+
+// ── TC-AUTH-002 ───────────────────────────────────────────────────────────────
+
+test.describe('TC-AUTH-002 — Login with valid and invalid credentials', () => {
+  let user: UserData;
+
+  test.beforeAll(async ({ request }) => {
+    user = {
+      email: uniqueEmail('auth002'),
+      password: 'TestPass123!',
+      full_name: 'Auth Test User',
+      role: 'STANDARD',
+    };
+    await createUser(request, user);
+  });
+
+  test('valid login reaches dashboard and allows access to protected route', async ({ page }) => {
+    await loginAs(page, user.email, user.password);
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    // Protected route loads without redirect back to /signin
+    await page.goto('/profile');
+    await expect(page).not.toHaveURL(/\/signin/);
+    await expect(page.getByText('Your Profile')).toBeVisible();
+  });
+
+  test('invalid password shows error message', async ({ page }) => {
+    await page.goto('/signin');
+    await page.fill('#email', user.email);
+    await page.fill('#password', 'wrongpassword');
+    await page.click('button:has-text("Sign In")');
+
+    await expect(page.locator('.alert-error')).toBeVisible();
+    await expect(page.locator('.alert-error')).toContainText(/invalid/i);
+  });
+});

--- a/frontend/tests/e2e/forum.spec.ts
+++ b/frontend/tests/e2e/forum.spec.ts
@@ -23,8 +23,9 @@ test('TC-FORUM-001 — create a forum post and verify it appears in the list', a
   await loginAs(page, std.email, std.password);
   await page.goto('/forum');
 
-  // hub-selector-bar is position:fixed z-index:1000 and overlaps the button — force the click
-  await page.click('button:has-text("+ New Post")', { force: true });
+  // hub-selector-bar is position:fixed z-index:1000 and intercepts pointer events over this button;
+  // use JS .click() to fire the React handler directly, bypassing pointer routing
+  await page.locator('button:has-text("+ New Post")').evaluate(el => (el as HTMLElement).click());
   await page.waitForURL('**/forum/new');
 
   await page.fill('#title', 'Earthquake safety tips');

--- a/frontend/tests/e2e/forum.spec.ts
+++ b/frontend/tests/e2e/forum.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * TC-FORUM-001: Authenticated user creates a forum post and sees it in the list.
+ * TC-FORUM-002: Another user upvotes, toggles, downvotes, and verifies persistence.
+ */
+
+import { test, expect } from '@playwright/test';
+import { createUser, loginAs, uniqueEmail, UserData } from './helpers/users';
+
+let std: UserData;
+let exp: UserData;
+let postUrl: string;
+
+test.beforeAll(async ({ request }) => {
+  std = { email: uniqueEmail('forum-std'), password: 'TestPass123!', full_name: 'Forum Std User', role: 'STANDARD' };
+  exp = { email: uniqueEmail('forum-exp'), password: 'TestPass123!', full_name: 'Forum Exp User', role: 'EXPERT', category_id: 1 };
+  await createUser(request, std);
+  await createUser(request, exp);
+});
+
+// ── TC-FORUM-001 ──────────────────────────────────────────────────────────────
+
+test('TC-FORUM-001 — create a forum post and verify it appears in the list', async ({ page }) => {
+  await loginAs(page, std.email, std.password);
+  await page.goto('/forum');
+
+  await page.click('button:has-text("+ New Post")');
+  await page.waitForURL('**/forum/new');
+
+  await page.fill('#title', 'Earthquake safety tips');
+  await page.fill('#content', 'Store 3 days of water per person.');
+
+  await page.click('button:has-text("Create Post")');
+
+  // Redirects to the new post's detail page
+  await page.waitForURL(/\/forum\/posts\/\d+/);
+  postUrl = page.url();
+
+  await expect(page.getByText('Earthquake safety tips')).toBeVisible();
+
+  // Post also appears in the forum list
+  await page.goto('/forum');
+  await expect(page.getByText('Earthquake safety tips')).toBeVisible();
+});
+
+// ── TC-FORUM-002 ──────────────────────────────────────────────────────────────
+
+test('TC-FORUM-002 — upvote, toggle, downvote, and verify persistence', async ({ page }) => {
+  await loginAs(page, exp.email, exp.password);
+  await page.goto(postUrl);
+
+  const upvoteBtn = page.locator('[title="Upvote"]');
+  const downvoteBtn = page.locator('[title="Downvote"]');
+
+  // Vote buttons render as "▲ N" / "▼ N" — extract the trailing number
+  const parseCount = async (btn: typeof upvoteBtn): Promise<number> => {
+    const text = await btn.innerText();
+    return parseInt(text.replace(/\D+/g, ''), 10) || 0;
+  };
+
+  const initialUp = await parseCount(upvoteBtn);
+  const initialDown = await parseCount(downvoteBtn);
+
+  // Upvote — count +1, button becomes active
+  await upvoteBtn.click();
+  await expect(upvoteBtn).toHaveClass(/vote-active/);
+  await expect(upvoteBtn).toContainText(String(initialUp + 1));
+
+  // Toggle off — count returns to original
+  await upvoteBtn.click();
+  await expect(upvoteBtn).not.toHaveClass(/vote-active/);
+  await expect(upvoteBtn).toContainText(String(initialUp));
+
+  // Downvote — downvote count +1
+  await downvoteBtn.click();
+  await expect(downvoteBtn).toContainText(String(initialDown + 1));
+
+  // Reload — state persisted
+  await page.reload();
+  await expect(downvoteBtn).toContainText(String(initialDown + 1));
+  await expect(downvoteBtn).toHaveClass(/vote-active/);
+});

--- a/frontend/tests/e2e/forum.spec.ts
+++ b/frontend/tests/e2e/forum.spec.ts
@@ -23,7 +23,8 @@ test('TC-FORUM-001 — create a forum post and verify it appears in the list', a
   await loginAs(page, std.email, std.password);
   await page.goto('/forum');
 
-  await page.click('button:has-text("+ New Post")');
+  // hub-selector-bar is position:fixed z-index:1000 and overlaps the button — force the click
+  await page.click('button:has-text("+ New Post")', { force: true });
   await page.waitForURL('**/forum/new');
 
   await page.fill('#title', 'Earthquake safety tips');
@@ -31,15 +32,14 @@ test('TC-FORUM-001 — create a forum post and verify it appears in the list', a
 
   await page.click('button:has-text("Create Post")');
 
-  // Redirects to the new post's detail page
+  // PostCreatePage navigates to /forum?tab=GLOBAL on success, not the post detail
+  await page.waitForURL(/\/forum/);
+  await expect(page.getByText('Earthquake safety tips')).toBeVisible();
+
+  // Open the post detail to capture the URL for TC-FORUM-002
+  await page.locator('.post-card-title').filter({ hasText: 'Earthquake safety tips' }).click();
   await page.waitForURL(/\/forum\/posts\/\d+/);
   postUrl = page.url();
-
-  await expect(page.getByText('Earthquake safety tips')).toBeVisible();
-
-  // Post also appears in the forum list
-  await page.goto('/forum');
-  await expect(page.getByText('Earthquake safety tips')).toBeVisible();
 });
 
 // ── TC-FORUM-002 ──────────────────────────────────────────────────────────────

--- a/frontend/tests/e2e/help-requests.spec.ts
+++ b/frontend/tests/e2e/help-requests.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * TC-HELP-001: Standard user creates a help request; status shows OPEN.
+ * TC-HELP-002: Expert comments; status changes to Expert Responding.
+ * TC-HELP-003: Author marks request as resolved; button disappears for others.
+ */
+
+import { test, expect } from '@playwright/test';
+import { createUser, loginAs, logout, uniqueEmail, UserData } from './helpers/users';
+
+let std: UserData;
+let exp: UserData;
+let requestUrl: string;
+
+test.beforeAll(async ({ request }) => {
+  std = { email: uniqueEmail('help-std'), password: 'TestPass123!', full_name: 'Help Std User', role: 'STANDARD' };
+  exp = { email: uniqueEmail('help-exp'), password: 'TestPass123!', full_name: 'Help Exp User', role: 'EXPERT', category_id: 1 };
+  await createUser(request, std);
+  await createUser(request, exp);
+});
+
+// ── TC-HELP-001 ───────────────────────────────────────────────────────────────
+
+test('TC-HELP-001 — create a help request; status shows Open', async ({ page }) => {
+  await loginAs(page, std.email, std.password);
+  await page.goto('/help-requests');
+
+  await page.click('button:has-text("+ New Request")');
+  await page.waitForURL('**/help-requests/new');
+
+  await page.fill('#title', 'Need medical assistance');
+  await page.fill('#description', 'I need help with medication delivery');
+  await page.selectOption('#category', 'MEDICAL');
+  await page.selectOption('#urgency', 'HIGH');
+
+  await page.click('button:has-text("Submit Request")');
+  await page.waitForURL(/\/help-requests\/\d+/);
+  requestUrl = page.url();
+
+  // Detail page shows correct content and Open status
+  await expect(page.getByText('Need medical assistance')).toBeVisible();
+  await expect(page.locator('.badge').filter({ hasText: /open/i })).toBeVisible();
+
+  // Also appears in the list
+  await page.goto('/help-requests');
+  await expect(page.getByText('Need medical assistance')).toBeVisible();
+});
+
+// ── TC-HELP-002 ───────────────────────────────────────────────────────────────
+
+test('TC-HELP-002 — expert comments; status becomes Expert Responding', async ({ page }) => {
+  await loginAs(page, exp.email, exp.password);
+  await page.goto(requestUrl);
+
+  await expect(page.locator('.badge').filter({ hasText: /open/i })).toBeVisible();
+
+  // Expert posts a comment
+  await page.fill('.help-detail-textarea', 'I can help — contact me at 0555-xxx');
+  await page.click('button:has-text("Post Comment")');
+  await expect(page.getByText('I can help — contact me at 0555-xxx')).toBeVisible();
+
+  // Status updates after expert comment
+  await page.reload();
+  await expect(page.locator('.badge').filter({ hasText: /expert responding/i })).toBeVisible();
+
+  // Standard user sees the same status and the comment
+  await logout(page);
+  await loginAs(page, std.email, std.password);
+  await page.goto(requestUrl);
+  await expect(page.locator('.badge').filter({ hasText: /expert responding/i })).toBeVisible();
+  await expect(page.getByText('I can help — contact me at 0555-xxx')).toBeVisible();
+});
+
+// ── TC-HELP-003 ───────────────────────────────────────────────────────────────
+
+test('TC-HELP-003 — author marks as resolved; button hidden for others', async ({ page }) => {
+  await loginAs(page, std.email, std.password);
+  await page.goto(requestUrl);
+
+  const resolveBtn = page.locator('button:has-text("Mark as Resolved")');
+  await expect(resolveBtn).toBeVisible();
+  await resolveBtn.click();
+
+  // Status changes to Resolved
+  await expect(page.locator('.badge').filter({ hasText: /resolved/i })).toBeVisible();
+
+  // Resolve button is no longer shown
+  await expect(page.locator('button:has-text("Mark as Resolved")')).not.toBeVisible();
+
+  // Expert (non-author) also cannot see the resolve button
+  await logout(page);
+  await loginAs(page, exp.email, exp.password);
+  await page.goto(requestUrl);
+  await expect(page.locator('button:has-text("Mark as Resolved")')).not.toBeVisible();
+});

--- a/frontend/tests/e2e/helpers/users.ts
+++ b/frontend/tests/e2e/helpers/users.ts
@@ -1,0 +1,59 @@
+import { Page, APIRequestContext } from '@playwright/test';
+
+const API_BASE = process.env.VITE_API_BASE ?? 'http://127.0.0.1:8000';
+
+export interface UserData {
+  email: string;
+  password: string;
+  full_name: string;
+  role?: 'STANDARD' | 'EXPERT';
+  category_id?: number;
+}
+
+/** Returns a unique email to prevent cross-run state pollution. */
+export function uniqueEmail(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}@e2e.test`;
+}
+
+/**
+ * Creates a user via the Django register API.
+ * hub_id is omitted — optional in the backend, keeps tests hub-independent.
+ * For EXPERT users pass category_id=1 (First Aid/Medical, seeded by migration 0006).
+ */
+export async function createUser(request: APIRequestContext, data: UserData): Promise<void> {
+  const payload: Record<string, unknown> = {
+    full_name: data.full_name,
+    email: data.email,
+    password: data.password,
+    confirm_password: data.password,
+    role: data.role ?? 'STANDARD',
+  };
+  if (data.category_id !== undefined) payload.category_id = data.category_id;
+
+  const res = await request.post(`${API_BASE}/register`, { data: payload });
+  if (!res.ok()) {
+    const body = await res.text();
+    throw new Error(`createUser failed (${res.status()}): ${body}`);
+  }
+}
+
+/**
+ * Logs in via the UI sign-in form.
+ * Waits for redirect to /dashboard before returning.
+ */
+export async function loginAs(page: Page, email: string, password: string): Promise<void> {
+  await page.goto('/signin');
+  await page.fill('#email', email);
+  await page.fill('#password', password);
+  await page.click('button:has-text("Sign In")');
+  await page.waitForURL('**/dashboard');
+}
+
+/**
+ * Clears the auth token from localStorage and navigates to /signin.
+ * Use this between user switches in multi-user test flows.
+ */
+export async function logout(page: Page): Promise<void> {
+  await page.evaluate(() => localStorage.removeItem('token'));
+  await page.goto('/signin');
+}

--- a/frontend/tests/e2e/profile.spec.ts
+++ b/frontend/tests/e2e/profile.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Profile page: rendering, resource management, role-conditional expertise section,
+ * and authorization guard (other users cannot edit/delete your content).
+ */
+
+import { test, expect } from '@playwright/test';
+import { createUser, loginAs, logout, uniqueEmail, UserData } from './helpers/users';
+
+let std: UserData;
+let exp: UserData;
+let std2: UserData;
+
+test.beforeAll(async ({ request }) => {
+  std  = { email: uniqueEmail('profile-std'),  password: 'TestPass123!', full_name: 'Profile Std User',  role: 'STANDARD' };
+  exp  = { email: uniqueEmail('profile-exp'),  password: 'TestPass123!', full_name: 'Profile Exp User',  role: 'EXPERT', category_id: 1 };
+  std2 = { email: uniqueEmail('profile-std2'), password: 'TestPass123!', full_name: 'Profile Std2 User', role: 'STANDARD' };
+  await createUser(request, std);
+  await createUser(request, exp);
+  await createUser(request, std2);
+});
+
+// ── Profile rendering ─────────────────────────────────────────────────────────
+
+test('profile shows user name, email, and Personal Information section', async ({ page }) => {
+  await loginAs(page, std.email, std.password);
+  await page.goto('/profile');
+
+  await expect(page.getByText(std.full_name)).toBeVisible();
+  await expect(page.getByText(std.email)).toBeVisible();
+  await expect(page.getByText('Personal Information')).toBeVisible();
+});
+
+// ── Resource management ───────────────────────────────────────────────────────
+
+test('resource can be added and appears in the list', async ({ page }) => {
+  await loginAs(page, std.email, std.password);
+  await page.goto('/profile');
+
+  // Open the Resources accordion
+  await page.click('button:has-text("Resources")');
+  await expect(page.getByText('No resources added yet.')).toBeVisible();
+
+  // Open add form
+  await page.click('button:has-text("+ Add Resource")');
+
+  await page.fill('input[placeholder="e.g. Generator"]', 'Generator');
+  await page.fill('input[placeholder="e.g. Power"]', 'Power');
+
+  const qtyInput = page.locator('input[type="number"]');
+  await qtyInput.fill('2');
+
+  await page.click('button:has-text("Save")');
+
+  await expect(page.getByText('Generator')).toBeVisible();
+});
+
+// ── Role restriction — expertise section ──────────────────────────────────────
+
+test('expertise accordion is hidden for standard user', async ({ page }) => {
+  await loginAs(page, std.email, std.password);
+  await page.goto('/profile');
+  await expect(page.locator('button:has-text("Expertise Fields")')).not.toBeVisible();
+});
+
+test('expertise accordion is visible for expert user', async ({ page }) => {
+  await loginAs(page, exp.email, exp.password);
+  await page.goto('/profile');
+  await expect(page.locator('button:has-text("Expertise Fields")')).toBeVisible();
+});
+
+// ── Authorization guard ───────────────────────────────────────────────────────
+
+test('another user cannot edit or delete a post they did not create', async ({ page }) => {
+  // std creates a forum post
+  await loginAs(page, std.email, std.password);
+  await page.goto('/forum/new');
+  await page.fill('#title', 'Auth guard test post');
+  await page.fill('#content', 'This post belongs to std.');
+  await page.click('button:has-text("Create Post")');
+  await page.waitForURL(/\/forum\/posts\/\d+/);
+  const postUrl = page.url();
+
+  // std2 opens the same post — Edit and Delete must not be visible
+  await logout(page);
+  await loginAs(page, std2.email, std2.password);
+  await page.goto(postUrl);
+
+  await expect(page.locator('button:has-text("Edit")')).not.toBeVisible();
+  await expect(page.locator('button:has-text("Delete")')).not.toBeVisible();
+});

--- a/frontend/tests/e2e/profile.spec.ts
+++ b/frontend/tests/e2e/profile.spec.ts
@@ -77,6 +77,9 @@ test('another user cannot edit or delete a post they did not create', async ({ p
   await page.fill('#title', 'Auth guard test post');
   await page.fill('#content', 'This post belongs to std.');
   await page.click('button:has-text("Create Post")');
+  // PostCreatePage navigates to /forum?tab=GLOBAL on success, not the post detail
+  await page.waitForURL(/\/forum/);
+  await page.locator('.post-card-title').filter({ hasText: 'Auth guard test post' }).click();
   await page.waitForURL(/\/forum\/posts\/\d+/);
   const postUrl = page.url();
 

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage loads without error', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle('Neighborhood Emergency Hub');
+  await expect(page.locator('h1').first()).toBeVisible();
+});


### PR DESCRIPTION
## Description

Adds a full Playwright E2E test suite covering the MVP acceptance scenarios defined in issue #293. Tests run against the real Django + Vite stack in CI, using isolated per-run users created via the register API.

Includes a shared `tests/e2e/helpers/users.ts` utility module (`createUser`, `loginAs`, `logout`, `uniqueEmail`) to keep specs clean and prevent cross-run state pollution. Also updates the CI `e2e` job to seed a test hub via a targeted `manage.py shell` one-liner, replacing the outdated `populate_sample_data` dependency.

> ⚠️ **Dependency:** PR #302 (Playwright setup) must be merged before this PR.

## Related Issues

Closes #293

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] The commit message follows our guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [x] New and existing tests pass locally with my changes.
