### PR TITLE
test: add Espresso tests for forum, help request & profile flows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,14 +199,14 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-34-google-apis-x86_64
+          key: avd-30-default-x86_64
 
       - name: Create AVD snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
-          target: google_apis
+          api-level: 30
+          target: default
           arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
@@ -216,8 +216,8 @@ jobs:
       - name: Run instrumented tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
-          target: google_apis
+          api-level: 30
+          target: default
           arch: x86_64
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -52,6 +52,10 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+
+    testOptions {
+        animationsDisabled = true
+    }
 }
 
 dependencies {

--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -24,6 +24,7 @@ android {
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments["timeout_msec"] = "60000"
     }
 
     buildFeatures {

--- a/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/BaseInstrumentedTest.kt
+++ b/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/BaseInstrumentedTest.kt
@@ -1,5 +1,6 @@
 package com.bounswe2026group8.emergencyhub
 
+import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import com.bounswe2026group8.emergencyhub.api.RetrofitClient
 import com.bounswe2026group8.emergencyhub.auth.TokenManager
@@ -20,8 +21,22 @@ abstract class BaseInstrumentedTest {
 
     @Before
     open fun setUp() {
-        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val ctx = instrumentation.targetContext
         TokenManager(ctx).clear()
+
+        // Delete the Room DB so stale schemas from previous installs never cause
+        // "no such table" crashes on any developer's machine or CI runner.
+        ctx.deleteDatabase("offline_contacts_database")
+
+        // POST_NOTIFICATIONS is a runtime permission only on API 33+. Grant it via
+        // shell before any activity launches so the system dialog never steals
+        // Espresso's window focus. On API 30 the permission doesn't exist, so skip.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            instrumentation.uiAutomation
+                .executeShellCommand("pm grant ${ctx.packageName} android.permission.POST_NOTIFICATIONS")
+                .close()
+        }
 
         mockWebServer = MockWebServer()
         mockWebServer.start()

--- a/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/BaseInstrumentedTest.kt
+++ b/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/BaseInstrumentedTest.kt
@@ -38,6 +38,17 @@ abstract class BaseInstrumentedTest {
                 .close()
         }
 
+        // Revoke location permissions so DashboardActivity.preCacheOfflineData()
+        // takes the no-permission branch and returns immediately. Without this,
+        // getCurrentLocation() on an emulator without mock GPS configured registers
+        // a callback that never fires, causing Espresso to wait indefinitely.
+        instrumentation.uiAutomation
+            .executeShellCommand("pm revoke ${ctx.packageName} android.permission.ACCESS_FINE_LOCATION")
+            .close()
+        instrumentation.uiAutomation
+            .executeShellCommand("pm revoke ${ctx.packageName} android.permission.ACCESS_COARSE_LOCATION")
+            .close()
+
         mockWebServer = MockWebServer()
         mockWebServer.start()
         RetrofitClient.testBaseUrl = mockWebServer.url("/").toString()

--- a/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/auth/SignInActivityTest.kt
+++ b/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/auth/SignInActivityTest.kt
@@ -1,0 +1,110 @@
+package com.bounswe2026group8.emergencyhub.auth
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bounswe2026group8.emergencyhub.BaseInstrumentedTest
+import com.bounswe2026group8.emergencyhub.R
+import com.bounswe2026group8.emergencyhub.ui.SignInActivity
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Espresso instrumented tests for [SignInActivity].
+ *
+ * Covers TC-AUTH-002: valid login, invalid credentials, and empty-field validation.
+ * All HTTP calls are intercepted by MockWebServer via [BaseInstrumentedTest].
+ * POST_NOTIFICATIONS is pre-granted in BaseInstrumentedTest.setUp() for API 33+.
+ */
+@RunWith(AndroidJUnit4::class)
+class SignInActivityTest : BaseInstrumentedTest() {
+
+    // ── TC-AUTH-002a: valid login ─────────────────────────────────────────────────
+
+    @Test
+    fun validCredentials_navigatesToDashboard() {
+        // DashboardActivity makes several async calls (fetchMe, FCM token, hub load,
+        // mesh sync) — route all paths via Dispatcher to avoid exhausted-queue errors
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.path == "/login" ->
+                    MockResponse().setResponseCode(200).setBody(LOGIN_SUCCESS_JSON)
+                request.path == "/me" ->
+                    MockResponse().setResponseCode(200).setBody(USER_JSON)
+                request.path == "/hubs/" ->
+                    MockResponse().setResponseCode(200).setBody(HUBS_JSON)
+                else ->
+                    MockResponse().setResponseCode(200).setBody("{}")
+            }
+        }
+
+        ActivityScenario.launch(SignInActivity::class.java)
+
+        onView(withId(R.id.inputEmail))
+            .perform(replaceText("test@test.com"), closeSoftKeyboard())
+        onView(withId(R.id.inputPassword))
+            .perform(replaceText("password123"), closeSoftKeyboard())
+        onView(withId(R.id.btnSignIn)).perform(click())
+
+        // DashboardActivity takes over — verify its welcome text is visible
+        onView(withId(R.id.txtWelcome)).check(matches(isDisplayed()))
+    }
+
+    // ── TC-AUTH-002b: invalid credentials ────────────────────────────────────────
+
+    @Test
+    fun invalidCredentials_staysOnSignIn() {
+        // Only one request expected (POST /login → 400); Dashboard never launches
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(400)
+                .setBody("""{"message":"Invalid email or password"}""")
+        )
+
+        ActivityScenario.launch(SignInActivity::class.java)
+
+        onView(withId(R.id.inputEmail))
+            .perform(replaceText("test@test.com"), closeSoftKeyboard())
+        onView(withId(R.id.inputPassword))
+            .perform(replaceText("wrongpassword"), closeSoftKeyboard())
+        onView(withId(R.id.btnSignIn)).perform(click())
+
+        // Still on SignInActivity — email field and re-enabled button are visible
+        onView(withId(R.id.inputEmail)).check(matches(isDisplayed()))
+        onView(withId(R.id.btnSignIn)).check(matches(isEnabled()))
+    }
+
+    // ── TC-AUTH-002c: empty-field validation ─────────────────────────────────────
+
+    @Test
+    fun emptyFields_noRequestSent() {
+        ActivityScenario.launch(SignInActivity::class.java)
+
+        // Click sign-in with both fields empty
+        onView(withId(R.id.btnSignIn)).perform(click())
+
+        // Validation is client-side — no network call should be made
+        assertEquals(0, mockWebServer.requestCount)
+
+        // Still on SignInActivity
+        onView(withId(R.id.inputEmail)).check(matches(isDisplayed()))
+    }
+
+    // ── Shared response fixtures ──────────────────────────────────────────────────
+
+    companion object {
+        private const val LOGIN_SUCCESS_JSON = """{"message":"Login successful","token":"fake-jwt","refresh":"fake-refresh","user":{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD","hub":null,"neighborhood_address":null,"expertise_field":null}}"""
+        private const val USER_JSON = """{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD","hub":null,"neighborhood_address":null,"expertise_field":null}"""
+        private const val HUBS_JSON = """[{"id":1,"name":"Istanbul","slug":"istanbul"}]"""
+    }
+}

--- a/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/dashboard/DashboardActivityTest.kt
+++ b/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/dashboard/DashboardActivityTest.kt
@@ -1,0 +1,113 @@
+package com.bounswe2026group8.emergencyhub.dashboard
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onData
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bounswe2026group8.emergencyhub.BaseInstrumentedTest
+import com.bounswe2026group8.emergencyhub.R
+import com.bounswe2026group8.emergencyhub.ui.DashboardActivity
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.hamcrest.Matchers.anything
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Espresso instrumented tests for [DashboardActivity].
+ *
+ * Covers: dashboard renders core navigation elements, and hub selector
+ * is populated and triggers a backend update on selection.
+ *
+ * [injectToken] simulates a logged-in user. A [Dispatcher] routes all
+ * async calls (fetchMe, hub load, FCM token, mesh sync) to MockWebServer.
+ * POST_NOTIFICATIONS is pre-granted in BaseInstrumentedTest.setUp() for API 33+.
+ */
+@RunWith(AndroidJUnit4::class)
+class DashboardActivityTest : BaseInstrumentedTest() {
+
+    // ── Dashboard renders navigation cards ────────────────────────────────────────
+
+    @Test
+    fun dashboard_rendersNavigationCards() {
+        injectToken("fake-jwt-token")
+
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.path == "/me"    -> MockResponse().setResponseCode(200).setBody(USER_JSON)
+                request.path == "/hubs/" -> MockResponse().setResponseCode(200).setBody(HUBS_JSON)
+                else                     -> MockResponse().setResponseCode(200).setBody("{}")
+            }
+        }
+
+        ActivityScenario.launch(DashboardActivity::class.java).use {
+            onView(withId(R.id.txtWelcome)).check(matches(isDisplayed()))
+            onView(withId(R.id.cardForum)).check(matches(isDisplayed()))
+            onView(withId(R.id.cardHelpRequests)).check(matches(isDisplayed()))
+            onView(withId(R.id.cardProfile)).check(matches(isDisplayed()))
+            onView(withId(R.id.cardOfflineInfo)).check(matches(isDisplayed()))
+            onView(withId(R.id.spinnerHubSelector)).check(matches(isDisplayed()))
+        }
+    }
+
+    // ── Hub selector is populated and selection triggers backend update ────────────
+
+    @Test
+    fun hubSelector_populatedAndSelectionTriggersUpdate() {
+        injectToken("fake-jwt-token")
+
+        // CountDownLatch lets us block until the PATCH /me coroutine fires
+        val patchLatch = CountDownLatch(1)
+
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.path == "/me" && request.method == "GET" ->
+                    MockResponse().setResponseCode(200).setBody(USER_JSON)
+                request.path == "/hubs/" ->
+                    MockResponse().setResponseCode(200).setBody(TWO_HUBS_JSON)
+                request.path == "/me" && request.method == "PATCH" -> {
+                    patchLatch.countDown()
+                    MockResponse().setResponseCode(200).setBody(USER_ANKARA_JSON)
+                }
+                else ->
+                    MockResponse().setResponseCode(200).setBody("{}")
+            }
+        }
+
+        ActivityScenario.launch(DashboardActivity::class.java).use {
+            // Hub spinner must be visible and populated by HubSelectorHelper.load()
+            onView(withId(R.id.spinnerHubSelector)).check(matches(isDisplayed()))
+
+            // Select the second hub (Ankara, index 1) — triggers PATCH /me
+            onView(withId(R.id.spinnerHubSelector)).perform(click())
+            onData(anything()).atPosition(1).perform(click())
+
+            // Verify the PATCH reached MockWebServer within 5 seconds
+            assertTrue(
+                "Expected PATCH /me to be called after hub selection",
+                patchLatch.await(5, TimeUnit.SECONDS)
+            )
+        }
+    }
+
+    // ── Shared response fixtures ──────────────────────────────────────────────────
+
+    companion object {
+        private const val USER_JSON =
+            """{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD","hub":null,"neighborhood_address":null,"expertise_field":null}"""
+        private const val HUBS_JSON =
+            """[{"id":1,"name":"Istanbul","slug":"istanbul"}]"""
+        private const val TWO_HUBS_JSON =
+            """[{"id":1,"name":"Istanbul","slug":"istanbul"},{"id":2,"name":"Ankara","slug":"ankara"}]"""
+        private const val USER_ANKARA_JSON =
+            """{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD","hub":{"id":2,"name":"Ankara","slug":"ankara"},"neighborhood_address":null,"expertise_field":null}"""
+    }
+}

--- a/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/forum/ForumActivityTest.kt
+++ b/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/forum/ForumActivityTest.kt
@@ -1,0 +1,97 @@
+package com.bounswe2026group8.emergencyhub.forum
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bounswe2026group8.emergencyhub.BaseInstrumentedTest
+import com.bounswe2026group8.emergencyhub.R
+import com.bounswe2026group8.emergencyhub.ui.ForumActivity
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Espresso instrumented tests for [ForumActivity].
+ *
+ * Covers: forum list renders mocked posts, and tapping a post opens
+ * [com.bounswe2026group8.emergencyhub.ui.PostDetailActivity].
+ *
+ * All HTTP calls are intercepted by MockWebServer via [BaseInstrumentedTest].
+ */
+@RunWith(AndroidJUnit4::class)
+class ForumActivityTest : BaseInstrumentedTest() {
+
+    // ── Forum list renders posts ───────────────────────────────────────────────────
+
+    @Test
+    fun forumList_rendersPosts() {
+        injectToken("fake-jwt-token")
+
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.path?.startsWith("/forum/posts/") == true ->
+                    MockResponse().setResponseCode(200).setBody(POSTS_JSON)
+                request.path == "/hubs/" ->
+                    MockResponse().setResponseCode(200).setBody(HUBS_JSON)
+                else ->
+                    MockResponse().setResponseCode(200).setBody("{}")
+            }
+        }
+
+        ActivityScenario.launch(ForumActivity::class.java).use {
+            onView(withText("Test Post")).check(matches(isDisplayed()))
+        }
+    }
+
+    // ── Tapping a post opens PostDetailActivity ────────────────────────────────────
+
+    @Test
+    fun postClick_opensPostDetail() {
+        injectToken("fake-jwt-token")
+
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                // Most specific first: comments endpoint
+                request.path?.startsWith("/forum/posts/") == true &&
+                        request.path?.contains("/comments/") == true ->
+                    MockResponse().setResponseCode(200).setBody("[]")
+                // Post detail (exact path, no query string)
+                request.path == "/forum/posts/1/" ->
+                    MockResponse().setResponseCode(200).setBody(POST_JSON)
+                // Posts list (catches /forum/posts/?forum_type=...)
+                request.path?.startsWith("/forum/posts/") == true ->
+                    MockResponse().setResponseCode(200).setBody(POSTS_JSON)
+                request.path == "/hubs/" ->
+                    MockResponse().setResponseCode(200).setBody(HUBS_JSON)
+                else ->
+                    MockResponse().setResponseCode(200).setBody("{}")
+            }
+        }
+
+        ActivityScenario.launch(ForumActivity::class.java).use {
+            // Wait for list to load, then click the post title
+            onView(withText("Test Post")).perform(click())
+
+            // PostDetailActivity is now in the foreground
+            onView(withId(R.id.txtPostTitle)).check(matches(isDisplayed()))
+        }
+    }
+
+    // ── Shared response fixtures ──────────────────────────────────────────────────
+
+    companion object {
+        private const val HUBS_JSON =
+            """[{"id":1,"name":"Istanbul","slug":"istanbul"}]"""
+        private const val POSTS_JSON =
+            """[{"id":1,"hub":null,"hub_name":null,"forum_type":"GLOBAL","author":{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD"},"title":"Test Post","content":"Test content","image_urls":[],"status":"PUBLISHED","upvote_count":0,"downvote_count":0,"comment_count":1,"repost_count":0,"user_vote":null,"user_has_reposted":false,"reposted_from":null,"created_at":"2026-01-01T00:00:00Z"}]"""
+        private const val POST_JSON =
+            """{"id":1,"hub":null,"hub_name":null,"forum_type":"GLOBAL","author":{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD"},"title":"Test Post","content":"Test content","image_urls":[],"status":"PUBLISHED","upvote_count":0,"downvote_count":0,"comment_count":1,"repost_count":0,"user_vote":null,"user_has_reposted":false,"reposted_from":null,"created_at":"2026-01-01T00:00:00Z"}"""
+    }
+}

--- a/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/forum/PostDetailActivityTest.kt
+++ b/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/forum/PostDetailActivityTest.kt
@@ -1,0 +1,123 @@
+package com.bounswe2026group8.emergencyhub.forum
+
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bounswe2026group8.emergencyhub.BaseInstrumentedTest
+import com.bounswe2026group8.emergencyhub.R
+import com.bounswe2026group8.emergencyhub.ui.PostDetailActivity
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Espresso instrumented tests for [PostDetailActivity].
+ *
+ * Covers: post detail screen renders content and comments, and comment
+ * submission reaches the backend.
+ *
+ * All HTTP calls are intercepted by MockWebServer via [BaseInstrumentedTest].
+ */
+@RunWith(AndroidJUnit4::class)
+class PostDetailActivityTest : BaseInstrumentedTest() {
+
+    // ── Post detail renders content and comments ───────────────────────────────────
+
+    @Test
+    fun postDetail_rendersContent() {
+        injectToken("fake-jwt-token")
+
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.path?.startsWith("/forum/posts/") == true &&
+                        request.path?.contains("/comments/") == true ->
+                    MockResponse().setResponseCode(200).setBody(COMMENTS_JSON)
+                request.path == "/forum/posts/1/" ->
+                    MockResponse().setResponseCode(200).setBody(POST_JSON)
+                request.path == "/hubs/" ->
+                    MockResponse().setResponseCode(200).setBody(HUBS_JSON)
+                else ->
+                    MockResponse().setResponseCode(200).setBody("{}")
+            }
+        }
+
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val intent = Intent(ctx, PostDetailActivity::class.java).putExtra("post_id", 1)
+        ActivityScenario.launch<PostDetailActivity>(intent).use {
+            onView(withId(R.id.txtPostTitle)).check(matches(isDisplayed()))
+            onView(withId(R.id.txtPostContent)).check(matches(isDisplayed()))
+            onView(withId(R.id.txtPostAuthor)).check(matches(isDisplayed()))
+            // Comment loaded from mock
+            onView(withText("Great post")).check(matches(isDisplayed()))
+        }
+    }
+
+    // ── Comment submission sends POST to backend ──────────────────────────────────
+
+    @Test
+    fun commentSubmission_sendsRequest() {
+        injectToken("fake-jwt-token")
+
+        val commentLatch = CountDownLatch(1)
+
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.path?.startsWith("/forum/posts/") == true &&
+                        request.path?.contains("/comments/") == true &&
+                        request.method == "POST" -> {
+                    commentLatch.countDown()
+                    MockResponse().setResponseCode(201).setBody(NEW_COMMENT_JSON)
+                }
+                request.path?.startsWith("/forum/posts/") == true &&
+                        request.path?.contains("/comments/") == true ->
+                    MockResponse().setResponseCode(200).setBody("[]")
+                request.path == "/forum/posts/1/" ->
+                    MockResponse().setResponseCode(200).setBody(POST_JSON)
+                request.path == "/hubs/" ->
+                    MockResponse().setResponseCode(200).setBody(HUBS_JSON)
+                else ->
+                    MockResponse().setResponseCode(200).setBody("{}")
+            }
+        }
+
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val intent = Intent(ctx, PostDetailActivity::class.java).putExtra("post_id", 1)
+        ActivityScenario.launch<PostDetailActivity>(intent).use {
+            onView(withId(R.id.inputComment))
+                .perform(replaceText("My comment"), closeSoftKeyboard())
+            onView(withId(R.id.btnPostComment)).perform(click())
+
+            assertTrue(
+                "Expected POST /forum/posts/1/comments/ to be called",
+                commentLatch.await(5, TimeUnit.SECONDS)
+            )
+        }
+    }
+
+    // ── Shared response fixtures ──────────────────────────────────────────────────
+
+    companion object {
+        private const val HUBS_JSON =
+            """[{"id":1,"name":"Istanbul","slug":"istanbul"}]"""
+        private const val POST_JSON =
+            """{"id":1,"hub":null,"hub_name":null,"forum_type":"GLOBAL","author":{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD"},"title":"Test Post","content":"Test content","image_urls":[],"status":"PUBLISHED","upvote_count":0,"downvote_count":0,"comment_count":1,"repost_count":0,"user_vote":null,"user_has_reposted":false,"reposted_from":null,"created_at":"2026-01-01T00:00:00Z"}"""
+        private const val COMMENTS_JSON =
+            """[{"id":1,"post":1,"author":{"id":2,"full_name":"Other User","email":"other@test.com","role":"STANDARD"},"content":"Great post","created_at":"2026-01-01T00:01:00Z"}]"""
+        private const val NEW_COMMENT_JSON =
+            """{"id":2,"post":1,"author":{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD"},"content":"My comment","created_at":"2026-01-01T00:02:00Z"}"""
+    }
+}

--- a/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/helprequest/HelpRequestDetailActivityTest.kt
+++ b/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/helprequest/HelpRequestDetailActivityTest.kt
@@ -1,0 +1,70 @@
+package com.bounswe2026group8.emergencyhub.helprequest
+
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bounswe2026group8.emergencyhub.BaseInstrumentedTest
+import com.bounswe2026group8.emergencyhub.R
+import com.bounswe2026group8.emergencyhub.ui.HelpRequestDetailActivity
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Espresso instrumented tests for [HelpRequestDetailActivity].
+ *
+ * Covers: help request detail screen renders title, category, status,
+ * and description from a mocked backend response.
+ *
+ * All HTTP calls are intercepted by MockWebServer via [BaseInstrumentedTest].
+ */
+@RunWith(AndroidJUnit4::class)
+class HelpRequestDetailActivityTest : BaseInstrumentedTest() {
+
+    // ── Help request detail renders all fields ─────────────────────────────────────
+
+    @Test
+    fun helpRequestDetail_rendersContent() {
+        injectToken("fake-jwt-token")
+
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.path?.startsWith("/help-requests/") == true &&
+                        request.path?.contains("/comments/") == true ->
+                    MockResponse().setResponseCode(200).setBody("[]")
+                request.path == "/help-requests/1/" ->
+                    MockResponse().setResponseCode(200).setBody(HELP_REQUEST_DETAIL_JSON)
+                request.path == "/hubs/" ->
+                    MockResponse().setResponseCode(200).setBody(HUBS_JSON)
+                else ->
+                    MockResponse().setResponseCode(200).setBody("{}")
+            }
+        }
+
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        val intent = Intent(ctx, HelpRequestDetailActivity::class.java)
+            .putExtra(HelpRequestDetailActivity.EXTRA_REQUEST_ID, 1)
+        ActivityScenario.launch<HelpRequestDetailActivity>(intent).use {
+            onView(withId(R.id.txtDetailTitle)).check(matches(isDisplayed()))
+            onView(withId(R.id.txtDetailCategory)).check(matches(isDisplayed()))
+            onView(withId(R.id.txtDetailStatus)).check(matches(isDisplayed()))
+            onView(withId(R.id.txtDetailDescription)).check(matches(isDisplayed()))
+        }
+    }
+
+    // ── Shared response fixtures ──────────────────────────────────────────────────
+
+    companion object {
+        private const val HUBS_JSON =
+            """[{"id":1,"name":"Istanbul","slug":"istanbul"}]"""
+        private const val HELP_REQUEST_DETAIL_JSON =
+            """{"id":1,"hub":null,"hub_name":null,"category":"MEDICAL","urgency":"HIGH","author":{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD","hub":null,"neighborhood_address":null,"expertise_field":null},"title":"Need insulin","description":"I need insulin urgently","image_urls":[],"latitude":null,"longitude":null,"location_text":null,"status":"OPEN","comment_count":0,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}"""
+    }
+}

--- a/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/helprequest/HelpRequestListActivityTest.kt
+++ b/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/helprequest/HelpRequestListActivityTest.kt
@@ -1,0 +1,104 @@
+package com.bounswe2026group8.emergencyhub.helprequest
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bounswe2026group8.emergencyhub.BaseInstrumentedTest
+import com.bounswe2026group8.emergencyhub.R
+import com.bounswe2026group8.emergencyhub.ui.HelpRequestListActivity
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Espresso instrumented tests for [HelpRequestListActivity].
+ *
+ * Covers: help request list renders mocked requests, and tapping a request
+ * opens [com.bounswe2026group8.emergencyhub.ui.HelpRequestDetailActivity].
+ *
+ * All HTTP calls are intercepted by MockWebServer via [BaseInstrumentedTest].
+ */
+@RunWith(AndroidJUnit4::class)
+class HelpRequestListActivityTest : BaseInstrumentedTest() {
+
+    // ── Help request list renders mocked items ─────────────────────────────────────
+
+    @Test
+    fun helpRequestList_rendersMockedRequests() {
+        injectToken("fake-jwt-token")
+
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.path?.startsWith("/help-requests/") == true ->
+                    MockResponse().setResponseCode(200).setBody(HELP_REQUESTS_JSON)
+                request.path == "/hubs/" ->
+                    MockResponse().setResponseCode(200).setBody(HUBS_JSON)
+                else ->
+                    MockResponse().setResponseCode(200).setBody("[]")
+            }
+        }
+
+        ActivityScenario.launch(HelpRequestListActivity::class.java).use {
+            onView(withText("Need insulin")).check(matches(isDisplayed()))
+        }
+    }
+
+    // ── Tapping a request opens HelpRequestDetailActivity ─────────────────────────
+
+    @Test
+    fun requestClick_opensDetailActivity() {
+        injectToken("fake-jwt-token")
+
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                // Most specific first: comments for detail
+                request.path?.startsWith("/help-requests/") == true &&
+                        request.path?.contains("/comments/") == true ->
+                    MockResponse().setResponseCode(200).setBody("[]")
+                // Detail endpoint (exact path for id=1)
+                request.path == "/help-requests/1/" ->
+                    MockResponse().setResponseCode(200).setBody(HELP_REQUEST_DETAIL_JSON)
+                // List endpoint (catches /help-requests/?... query params)
+                request.path?.startsWith("/help-requests/") == true ->
+                    MockResponse().setResponseCode(200).setBody(HELP_REQUESTS_JSON)
+                // Return 404 for hubs so HubSelectorHelper skips setupSpinner().
+                // If hubs load successfully, setupSpinner() calls onHubSelected which
+                // triggers a second fetchHelpRequests() → showLoading() hides the
+                // RecyclerView → Espresso's click dispatches to (0,0) and navigation
+                // never fires. A 404 prevents that second call entirely.
+                request.path == "/hubs/" ->
+                    MockResponse().setResponseCode(404).setBody("{}")
+                else ->
+                    MockResponse().setResponseCode(200).setBody("[]")
+            }
+        }
+
+        ActivityScenario.launch(HelpRequestListActivity::class.java).use {
+            // Wait for the list to load, then click the card (click listener is on
+            // the card container, not the title text view)
+            onView(withText("Need insulin")).check(matches(isDisplayed()))
+            onView(withId(R.id.cardHelpRequest)).perform(click())
+
+            // HelpRequestDetailActivity is now in the foreground
+            onView(withId(R.id.txtDetailTitle)).check(matches(isDisplayed()))
+        }
+    }
+
+    // ── Shared response fixtures ──────────────────────────────────────────────────
+
+    companion object {
+        private const val HUBS_JSON =
+            """[{"id":1,"name":"Istanbul","slug":"istanbul"}]"""
+        private const val HELP_REQUESTS_JSON =
+            """[{"id":1,"hub":null,"hub_name":null,"category":"MEDICAL","urgency":"HIGH","author":{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD","hub":null,"neighborhood_address":null,"expertise_field":null},"title":"Need insulin","status":"OPEN","comment_count":0,"created_at":"2026-01-01T00:00:00Z"}]"""
+        private const val HELP_REQUEST_DETAIL_JSON =
+            """{"id":1,"hub":null,"hub_name":null,"category":"MEDICAL","urgency":"HIGH","author":{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD","hub":null,"neighborhood_address":null,"expertise_field":null},"title":"Need insulin","description":"I need insulin urgently","image_urls":[],"latitude":null,"longitude":null,"location_text":null,"status":"OPEN","comment_count":0,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}"""
+    }
+}

--- a/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/profile/ProfileActivityTest.kt
+++ b/mobile/app/src/androidTest/java/com/bounswe2026group8/emergencyhub/profile/ProfileActivityTest.kt
@@ -1,0 +1,91 @@
+package com.bounswe2026group8.emergencyhub.profile
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bounswe2026group8.emergencyhub.BaseInstrumentedTest
+import com.bounswe2026group8.emergencyhub.R
+import com.bounswe2026group8.emergencyhub.api.UserData
+import com.bounswe2026group8.emergencyhub.auth.TokenManager
+import com.bounswe2026group8.emergencyhub.ui.ProfileActivity
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Espresso instrumented tests for [ProfileActivity].
+ *
+ * Covers: profile screen renders the logged-in user's name, email, and role badge.
+ *
+ * [ProfileActivity.loadIdentity] reads from [TokenManager] synchronously, so the
+ * user object must be pre-seeded before the activity launches (not via a /me call).
+ *
+ * All HTTP calls are intercepted by MockWebServer via [BaseInstrumentedTest].
+ */
+@RunWith(AndroidJUnit4::class)
+class ProfileActivityTest : BaseInstrumentedTest() {
+
+    // ── Profile screen renders user data ──────────────────────────────────────────
+
+    @Test
+    fun profile_rendersUserData() {
+        injectToken("fake-jwt-token")
+
+        // ProfileActivity reads identity from TokenManager cache synchronously.
+        // Pre-seed the user object so name/email/role are available immediately.
+        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
+        TokenManager(ctx).saveUser(
+            UserData(
+                id = 1,
+                fullName = "Test User",
+                email = "test@test.com",
+                role = "STANDARD",
+                hub = null,
+                neighborhoodAddress = null,
+                expertiseField = null
+            )
+        )
+
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse = when {
+                request.path == "/me" ->
+                    MockResponse().setResponseCode(200).setBody(USER_JSON)
+                request.path == "/profile" ->
+                    MockResponse().setResponseCode(200).setBody(PROFILE_JSON)
+                request.path == "/resources" ->
+                    MockResponse().setResponseCode(200).setBody("[]")
+                request.path == "/expertise" ->
+                    MockResponse().setResponseCode(200).setBody("[]")
+                request.path?.startsWith("/expertise-categories/") == true ->
+                    MockResponse().setResponseCode(200).setBody("[]")
+                request.path == "/hubs/" ->
+                    MockResponse().setResponseCode(200).setBody(HUBS_JSON)
+                else ->
+                    MockResponse().setResponseCode(200).setBody("{}")
+            }
+        }
+
+        ActivityScenario.launch(ProfileActivity::class.java).use {
+            onView(withId(R.id.txtFullName)).check(matches(isDisplayed()))
+            onView(withId(R.id.txtEmail)).check(matches(isDisplayed()))
+            onView(withId(R.id.txtRoleBadge)).check(matches(isDisplayed()))
+        }
+    }
+
+    // ── Shared response fixtures ──────────────────────────────────────────────────
+
+    companion object {
+        private const val HUBS_JSON =
+            """[{"id":1,"name":"Istanbul","slug":"istanbul"}]"""
+        private const val USER_JSON =
+            """{"id":1,"full_name":"Test User","email":"test@test.com","role":"STANDARD","hub":null,"neighborhood_address":null,"expertise_field":null}"""
+        private const val PROFILE_JSON =
+            """{"phone_number":null,"blood_type":null,"emergency_contact_phone":null,"special_needs":null,"has_disability":false,"availability_status":"SAFE","bio":null,"preferred_language":"en","emergency_contact":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}"""
+    }
+}


### PR DESCRIPTION
## Description

Adds Espresso instrumented UI tests for the forum, help request, and profile flows (Issue #291), using the same MockWebServer pattern established in #290.

All network calls are intercepted by `MockWebServer` — no real backend is needed. Several reliability fixes are included to make the suite pass consistently on any machine and in CI:

- Revoke location permissions in `BaseInstrumentedTest.setUp()` so `DashboardActivity.preCacheOfflineData()` skips the `getCurrentLocation()` call that hangs indefinitely on emulators without mock GPS configured
- Return 404 for `/hubs/` in the `requestClick_opensDetailActivity` test to prevent `HubSelectorHelper` from triggering a second `fetchHelpRequests()` that calls `showLoading()` mid-click, hiding the RecyclerView and causing Espresso to dispatch the click to coordinates (0,0)
- Add `timeout_msec = 60000` per-test timeout so a hanging test fails in under a minute instead of blocking the entire suite
- Drop CI emulator from API 34 to API 30 — API 31+ strictly enforces the hidden API blocklist which blocks `InputManager.getInstance()`, breaking Espresso's input injection even for basic `click()` actions

## Running locally

**Required:** Android emulator running **API 30** (Pixel 4 or equivalent). API 31+ breaks Espresso's input injection on stock AOSP emulators due to hidden API enforcement.

Create the AVD in Android Studio → Device Manager → Pixel 4 → API 30 (Android 11), then run:

```bash
cd mobile
./gradlew connectedDebugAndroidTest 
```

## Related Issues
Closes #290 
Closes #291 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] The commit message follows our guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [x] New and existing tests pass locally with my changes.
