### PR TITLE
fix: align mobile badge and help request translations

### DIFF
--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestAdapter.kt
@@ -55,7 +55,7 @@ class HelpRequestAdapter(
         holder.txtTimeAgo.text = TimeUtils.timeAgo(item.createdAt)
 
         if (item.isExpertResponding == true && item.assignedExpertUsername != null) {
-            holder.txtAssignedExpert.text = "Assigned to: ${item.assignedExpertUsername}"
+            holder.txtAssignedExpert.text = ctx.getString(R.string.assigned_expert_format, item.assignedExpertUsername)
             holder.txtAssignedExpert.visibility = View.VISIBLE
         } else {
             holder.txtAssignedExpert.visibility = View.GONE

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestDetailActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestDetailActivity.kt
@@ -277,7 +277,7 @@ class HelpRequestDetailActivity : AppCompatActivity() {
             if (isAuthor && detail.status != "RESOLVED") View.VISIBLE else View.GONE
 
         if (detail.isExpertResponding == true && detail.assignedExpertUsername != null) {
-            txtAssignedExpert.text = "Assigned to: ${detail.assignedExpertUsername}"
+            txtAssignedExpert.text = getString(R.string.assigned_expert_format, detail.assignedExpertUsername)
             txtAssignedExpert.visibility = View.VISIBLE
         } else {
             txtAssignedExpert.visibility = View.GONE

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App -->
     <string name="app_name">Emergency Hub</string>
@@ -538,14 +538,15 @@
     <string name="feature_settings">Ajustes</string>
     <string name="feature_settings_desc">Privacidad y alertas</string>
 
-    <string name="badge_name_commenter">Comentarista</string>
-    <string name="badge_desc_commenter">Otorgado por comentar.</string>
+    <string name="badge_name_commenter">Conversador</string>
+    <string name="badge_desc_commenter">Otorgada por participar activamente en las discusiones de la comunidad.</string>
     <string name="badge_name_voter">Votante</string>
-    <string name="badge_desc_voter">Otorgado por votar en publicaciones.</string>
+    <string name="badge_desc_voter">Otorgada por votar en las publicaciones de la comunidad.</string>
     <string name="badge_name_forum_active">Foro Activo</string>
-    <string name="badge_desc_forum_active">Obtenido por crear publicaciones en el foro.</string>
+    <string name="badge_desc_forum_active">Otorgada por crear nuevas publicaciones en el foro de la comunidad.</string>
     <string name="badge_name_responder">Respondedor</string>
-    <string name="badge_desc_responder">Otorgado por responder a solicitudes de ayuda.</string>
+    <string name="badge_desc_responder">Otorgada por asumir la responsabilidad de las solicitudes de ayuda de la comunidad.</string>
+    <string name="assigned_expert_format">Asignado a: %1$s</string>
 </resources>
 
 

--- a/mobile/app/src/main/res/values-tr/strings.xml
+++ b/mobile/app/src/main/res/values-tr/strings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App -->
     <string name="app_name">Emergency Hub</string>
@@ -562,14 +562,15 @@
     <string name="feature_settings">Ayarlar</string>
     <string name="feature_settings_desc">Gizlilik ve uyarılar</string>
 
-    <string name="badge_name_commenter">Yorumcu</string>
-    <string name="badge_desc_commenter">Yorum yaptığınız için verilir.</string>
-    <string name="badge_name_voter">Oylayıcı</string>
-    <string name="badge_desc_voter">Gönderilere oy verdiğiniz için verilir.</string>
-    <string name="badge_name_forum_active">Forum Aktifi</string>
-    <string name="badge_desc_forum_active">Forum gönderileri oluşturarak kazanılır.</string>
-    <string name="badge_name_responder">Yanıtlayıcı</string>
-    <string name="badge_desc_responder">Yardım taleplerine yanıt verdiğiniz için verilir.</string>
+    <string name="badge_name_commenter">Sohbetçi</string>
+    <string name="badge_desc_commenter">Topluluk tartışmalarına aktif olarak katıldığınız için verilir.</string>
+    <string name="badge_name_voter">Oy Veren</string>
+    <string name="badge_desc_voter">Topluluk gönderilerini oyladığınız için verilir.</string>
+    <string name="badge_name_forum_active">Aktif Forumcu</string>
+    <string name="badge_desc_forum_active">Topluluk forumunda yeni gönderiler oluşturduğunuz için verilir.</string>
+    <string name="badge_name_responder">Yardımsever</string>
+    <string name="badge_desc_responder">Topluluk yardım taleplerinin sorumluluğunu üstlendiğiniz için verilir.</string>
+    <string name="assigned_expert_format">Atanan: %1$s</string>
 </resources>
 
 

--- a/mobile/app/src/main/res/values-zh/strings.xml
+++ b/mobile/app/src/main/res/values-zh/strings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App -->
     <string name="app_name">Emergency Hub</string>
@@ -538,14 +538,15 @@
     <string name="feature_settings">设置</string>
     <string name="feature_settings_desc">隐私和警报</string>
 
-    <string name="badge_name_commenter">评论者</string>
-    <string name="badge_desc_commenter">因发表评论而获得。</string>
+    <string name="badge_name_commenter">社交達人</string>
+    <string name="badge_desc_commenter">獎勵給積極參與社區討論的用戶。</string>
     <string name="badge_name_voter">投票者</string>
-    <string name="badge_desc_voter">因对帖子投票而获得。</string>
-    <string name="badge_name_forum_active">活跃论坛</string>
-    <string name="badge_desc_forum_active">通过创建论坛帖子获得。</string>
-    <string name="badge_name_responder">响应者</string>
-    <string name="badge_desc_responder">因响应帮助请求而获得。</string>
+    <string name="badge_desc_voter">獎勵給對社區貼文進行投票的用戶。</string>
+    <string name="badge_name_forum_active">論壇活躍者</string>
+    <string name="badge_desc_forum_active">獎勵給在社區論壇中發佈新貼文的用戶。</string>
+    <string name="badge_name_responder">響應者</string>
+    <string name="badge_desc_responder">獎勵給承擔社區求助請求責任的用戶。</string>
+    <string name="assigned_expert_format">已分配给: %1$s</string>
 </resources>
 
 

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App -->
     <string name="app_name">Emergency Hub</string>
@@ -666,12 +666,13 @@
     <string name="badges_pill_format" translatable="false">%1$s %2$s</string>
     <string name="arrow_right" translatable="false">→</string>
     <string name="badge_name_commenter">Commenter</string>
-    <string name="badge_desc_commenter">Awarded for commenting.</string>
+    <string name="badge_desc_commenter">Awarded for being an active participant in community discussions.</string>
     <string name="badge_name_voter">Voter</string>
-    <string name="badge_desc_voter">Awarded for voting on posts.</string>
+    <string name="badge_desc_voter">Awarded for voting on community posts.</string>
     <string name="badge_name_forum_active">Forum Active</string>
-    <string name="badge_desc_forum_active">Gained by creating Forum Posts</string>
+    <string name="badge_desc_forum_active">Awarded for creating new posts in the community forum.</string>
     <string name="badge_name_responder">Responder</string>
-    <string name="badge_desc_responder">Awarded for responding to Help Requests</string>
+    <string name="badge_desc_responder">Awarded for taking responsibility for community help requests.</string>
+    <string name="assigned_expert_format">Assigned to: %1$s</string>
 </resources>
 


### PR DESCRIPTION
## Description

This PR fixes Android mobile localization inconsistencies reported during review.

Changes include:
- Aligning mobile badge names and descriptions with the web translations.
- Updating Turkish, Spanish, Chinese, and default English string resources.
- Localizing the help request “Assigned to ...” label on mobile.
- Updating help request list/detail UI code to use localized string resources.

This does not change backend logic, web logic, or badge/reward behavior.

## Related Issues
Closes #323 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code Refactoring (no functional changes, no api changes)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] The commit message follows our guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [ ] New and existing tests pass locally with my changes.