### PR TITLE
fix: resolve all failing CI tests across backend, frontend, and Android

### DIFF
--- a/backend/accounts/test_staff.py
+++ b/backend/accounts/test_staff.py
@@ -28,7 +28,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from forum.models import Comment, Post, Report
 from help_requests.models import HelpComment, HelpOffer, HelpRequest
 
-from .models import ExpertiseField, Hub, StaffAuditLog, User
+from .models import ExpertiseCategory, ExpertiseField, Hub, StaffAuditLog, User
 from .permissions import (
     user_is_admin,
     user_is_moderator_or_admin,
@@ -55,7 +55,7 @@ class StaffBase(TestCase):
         )
         self.expert = User.objects.create_user(
             email='expert@example.com', full_name='Expert', password='Pass1234',
-            role=User.Role.EXPERT, expertise_field='First Aid', hub=self.hub,
+            role=User.Role.EXPERT, hub=self.hub,
         )
         self.moderator = User.objects.create_user(
             email='mod@example.com', full_name='Moderator', password='Pass1234',
@@ -549,9 +549,10 @@ class HelpModerationTests(StaffBase):
 class ExpertiseVerificationTests(StaffBase):
     def setUp(self):
         super().setUp()
+        self.cat = ExpertiseCategory.objects.first()
         self.expertise = ExpertiseField.objects.create(
             user=self.expert,
-            field='Cardiology',
+            category=self.cat,
             certification_level=ExpertiseField.CertificationLevel.ADVANCED,
             certification_document_url='https://example.com/cert.pdf',
         )
@@ -641,8 +642,9 @@ class ExpertiseVerificationTests(StaffBase):
         self.assertEqual(self.expertise.verification_note, '')
 
     def test_pending_queue(self):
+        other_cat = ExpertiseCategory.objects.exclude(pk=self.cat.pk).first()
         approved = ExpertiseField.objects.create(
-            user=self.expert, field='Surgery',
+            user=self.expert, category=other_cat,
             verification_status=ExpertiseField.VerificationStatus.APPROVED,
         )
         response = self.verifier_client.get('/staff/expertise-verifications/')

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -42,9 +42,11 @@ class RegisterTests(TestCase):
 
     def test_register_expert_user(self):
         """Expert user can register; expertise areas are added separately via /expertise."""
+        category = ExpertiseCategory.objects.filter(is_active=True).first()
         payload = self._base_payload(
             role='EXPERT',
             neighborhood_address='Sariyer, Istanbul',
+            category_id=category.pk,
         )
         response = self.client.post(self.url, payload, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -516,12 +518,12 @@ class ExpertiseCategoryTests(TestCase):
         self.assertEqual(inactive, 0)
 
     def test_inactive_category_excluded_from_serializer_queryset(self):
-        """An inactive category must not be selectable via the API."""
+        """An inactive category must not be selectable via the registration API."""
         cat = ExpertiseCategory.objects.get(name='First Aid')
         cat.is_active = False
         cat.save()
-        from .serializers import ExpertiseFieldSerializer
-        field = ExpertiseFieldSerializer().fields['category_id']
+        from .serializers import RegisterSerializer
+        field = RegisterSerializer().fields['category_id']
         active_ids = list(field.queryset.values_list('id', flat=True))
         self.assertNotIn(cat.pk, active_ids)
 
@@ -587,7 +589,7 @@ class ExpertiseFieldTests(TestCase):
 
     def _create_payload(self, **overrides):
         payload = {
-            'category_id': self.medical_cat.pk,
+            'category': self.medical_cat.pk,
             'certification_level': 'ADVANCED',
         }
         payload.update(overrides)
@@ -599,15 +601,14 @@ class ExpertiseFieldTests(TestCase):
         """Expert user can add an expertise field linked to a category."""
         response = self.expert_client.post('/expertise', self._create_payload(), format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['category']['id'], self.medical_cat.pk)
-        self.assertEqual(response.data['category']['name'], self.medical_cat.name)
+        self.assertEqual(response.data['category'], self.medical_cat.pk)
         self.assertEqual(response.data['certification_level'], 'ADVANCED')
 
     def test_expertise_field_is_approved_defaults_to_true(self):
         """Newly created expertise fields are approved by default."""
         response = self.expert_client.post('/expertise', self._create_payload(), format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(response.data['is_approved'])
+        self.assertTrue(ExpertiseField.objects.get(pk=response.data['id']).is_approved)
 
     def test_expert_can_list_own_expertise_fields(self):
         """Expert user can list their own expertise fields."""
@@ -616,8 +617,8 @@ class ExpertiseFieldTests(TestCase):
         )
         response = self.expert_client.get('/expertise')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        category_names = [e['category']['name'] for e in response.data]
-        self.assertIn(self.shelter_cat.name, category_names)
+        category_ids = [e['category'] for e in response.data]
+        self.assertIn(self.shelter_cat.pk, category_ids)
 
     def test_expert_can_delete_expertise_field(self):
         """Expert user can delete their own expertise field."""
@@ -630,7 +631,7 @@ class ExpertiseFieldTests(TestCase):
 
     def test_expertise_defaults_certification_level_to_beginner(self):
         """Omitting certification_level defaults to BEGINNER."""
-        payload = {'category_id': self.medical_cat.pk}
+        payload = {'category': self.medical_cat.pk}
         response = self.expert_client.post('/expertise', payload, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['certification_level'], 'BEGINNER')

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -256,7 +256,7 @@ class ExpertiseFieldDetailView(APIView):
     permission_classes = [IsAuthenticated]
 
     # Editable fields that re-trigger verification when changed.
-    _VERIFICATION_RESET_FIELDS = ('field', 'certification_level', 'certification_document_url')
+    _VERIFICATION_RESET_FIELDS = ('category_id', 'certification_level', 'certification_document_url')
 
     def _get_expertise(self, request, pk):
         if request.user.role != User.Role.EXPERT:

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -23,4 +23,7 @@ module.exports = {
 
   // Do not transform node_modules (except packages that ship ESM only)
   transformIgnorePatterns: ['/node_modules/(?!(.*\\.mjs$))'],
+
+  // Playwright e2e specs live under tests/ — Jest must not pick them up
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/tests/'],
 };

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -164,7 +164,7 @@ function BloodTypeSelect({ value, name, onSave, t }) {
 }
 
 const EMPTY_RESOURCE = { name: '', category: '', quantity: 1, condition: true };
-const EMPTY_EXPERTISE = { category_id: '', certification_level: 'BEGINNER', certification_document_url: '' };
+const EMPTY_EXPERTISE = { category: '', certification_level: 'BEGINNER', certification_document_url: '' };
 
 export default function ProfilePage() {
   const { user, refreshUser } = useAuth();
@@ -493,8 +493,8 @@ export default function ProfilePage() {
                       <div className="form-group">
                         <label>{t('profile.labels.field')}</label>
                         <select
-                          value={newExpertise.category_id}
-                          onChange={(e) => setNewExpertise((p) => ({ ...p, category_id: e.target.value }))}
+                          value={newExpertise.category}
+                          onChange={(e) => setNewExpertise((p) => ({ ...p, category: e.target.value }))}
                           required
                         >
                           <option value="">— {t('profile.placeholders.expertise_field')} —</option>

--- a/frontend/src/pages/ProfilePage.test.jsx
+++ b/frontend/src/pages/ProfilePage.test.jsx
@@ -99,6 +99,7 @@ describe('ProfilePage', () => {
     api.getResources.mockResolvedValue({ ok: true, data: [] });
     api.getExpertiseFields.mockResolvedValue({ ok: true, data: [] });
     api.getExpertiseCategories.mockResolvedValue({ ok: true, data: [] });
+    api.getMyBadges.mockResolvedValue({ ok: true, data: [] });
   });
 
   // ── Identity ─────────────────────────────────────────────────────────────────

--- a/frontend/tests/e2e/forum.spec.ts
+++ b/frontend/tests/e2e/forum.spec.ts
@@ -1,82 +1,90 @@
 /**
  * TC-FORUM-001: Authenticated user creates a forum post and sees it in the list.
  * TC-FORUM-002: Another user upvotes, toggles, downvotes, and verifies persistence.
+ *
+ * Tests run serially so postUrl set in TC-FORUM-001 is available to TC-FORUM-002.
  */
 
 import { test, expect } from '@playwright/test';
-import { createUser, loginAs, uniqueEmail, UserData } from './helpers/users';
+import { createUser, loginAs, uniqueEmail, uniqueTitle, UserData } from './helpers/users';
 
 let std: UserData;
 let exp: UserData;
 let postUrl: string;
+let postTitle: string;
 
-test.beforeAll(async ({ request }) => {
-  std = { email: uniqueEmail('forum-std'), password: 'TestPass123!', full_name: 'Forum Std User', role: 'STANDARD' };
-  exp = { email: uniqueEmail('forum-exp'), password: 'TestPass123!', full_name: 'Forum Exp User', role: 'EXPERT', category_id: 1 };
-  await createUser(request, std);
-  await createUser(request, exp);
-});
+test.describe.serial('Forum flows', () => {
 
-// ── TC-FORUM-001 ──────────────────────────────────────────────────────────────
+  test.beforeAll(async ({ request }) => {
+    std = { email: uniqueEmail('forum-std'), password: 'TestPass123!', full_name: 'Forum Std User', role: 'STANDARD' };
+    exp = { email: uniqueEmail('forum-exp'), password: 'TestPass123!', full_name: 'Forum Exp User', role: 'EXPERT', category_id: 1 };
+    postTitle = uniqueTitle('Earthquake safety tips');
+    await createUser(request, std);
+    await createUser(request, exp);
+  });
 
-test('TC-FORUM-001 — create a forum post and verify it appears in the list', async ({ page }) => {
-  await loginAs(page, std.email, std.password);
-  await page.goto('/forum');
+  // ── TC-FORUM-001 ──────────────────────────────────────────────────────────────
 
-  // hub-selector-bar is position:fixed z-index:1000 and intercepts pointer events over this button;
-  // use JS .click() to fire the React handler directly, bypassing pointer routing
-  await page.locator('button:has-text("+ New Post")').evaluate(el => (el as HTMLElement).click());
-  await page.waitForURL('**/forum/new');
+  test('TC-FORUM-001 — create a forum post and verify it appears in the list', async ({ page }) => {
+    await loginAs(page, std.email, std.password);
+    await page.goto('/forum');
 
-  await page.fill('#title', 'Earthquake safety tips');
-  await page.fill('#content', 'Store 3 days of water per person.');
+    // hub-selector-bar is position:fixed z-index:1000 and intercepts pointer events over this button;
+    // use JS .click() to fire the React handler directly, bypassing pointer routing
+    await page.locator('button:has-text("+ New Post")').evaluate(el => (el as HTMLElement).click());
+    await page.waitForURL('**/forum/new');
 
-  await page.click('button:has-text("Create Post")');
+    await page.fill('#title', postTitle);
+    await page.fill('#content', 'Store 3 days of water per person.');
 
-  // PostCreatePage navigates to /forum?tab=GLOBAL on success, not the post detail
-  await page.waitForURL(/\/forum/);
-  await expect(page.getByText('Earthquake safety tips')).toBeVisible();
+    await page.click('button:has-text("Create Post")');
 
-  // Open the post detail to capture the URL for TC-FORUM-002
-  await page.locator('.post-card-title').filter({ hasText: 'Earthquake safety tips' }).click();
-  await page.waitForURL(/\/forum\/posts\/\d+/);
-  postUrl = page.url();
-});
+    // PostCreatePage navigates to /forum?tab=GLOBAL on success, not the post detail
+    await page.waitForURL(/\/forum/);
+    await expect(page.getByText(postTitle)).toBeVisible();
 
-// ── TC-FORUM-002 ──────────────────────────────────────────────────────────────
+    // Open the post detail to capture the URL for TC-FORUM-002
+    await page.locator('.post-card-title').filter({ hasText: postTitle }).click();
+    await page.waitForURL(/\/forum\/posts\/\d+/);
+    postUrl = page.url();
+  });
 
-test('TC-FORUM-002 — upvote, toggle, downvote, and verify persistence', async ({ page }) => {
-  await loginAs(page, exp.email, exp.password);
-  await page.goto(postUrl);
+  // ── TC-FORUM-002 ──────────────────────────────────────────────────────────────
 
-  const upvoteBtn = page.locator('[title="Upvote"]');
-  const downvoteBtn = page.locator('[title="Downvote"]');
+  test('TC-FORUM-002 — upvote, toggle, downvote, and verify persistence', async ({ page }) => {
+    await loginAs(page, exp.email, exp.password);
+    await page.goto(postUrl);
 
-  // Vote buttons render as "▲ N" / "▼ N" — extract the trailing number
-  const parseCount = async (btn: typeof upvoteBtn): Promise<number> => {
-    const text = await btn.innerText();
-    return parseInt(text.replace(/\D+/g, ''), 10) || 0;
-  };
+    const upvoteBtn = page.locator('[title="Upvote"]');
+    const downvoteBtn = page.locator('[title="Downvote"]');
 
-  const initialUp = await parseCount(upvoteBtn);
-  const initialDown = await parseCount(downvoteBtn);
+    // Vote buttons render as "▲ N" / "▼ N" — extract the trailing number
+    const parseCount = async (btn: typeof upvoteBtn): Promise<number> => {
+      const text = await btn.innerText();
+      return parseInt(text.replace(/\D+/g, ''), 10) || 0;
+    };
 
-  // Upvote — count +1, button becomes active
-  await upvoteBtn.click();
-  await expect(upvoteBtn).toHaveClass(/vote-active/);
-  await expect(upvoteBtn).toContainText(String(initialUp + 1));
+    const initialUp = await parseCount(upvoteBtn);
+    const initialDown = await parseCount(downvoteBtn);
 
-  // Toggle off — count returns to original
-  await upvoteBtn.click();
-  await expect(upvoteBtn).not.toHaveClass(/vote-active/);
-  await expect(upvoteBtn).toContainText(String(initialUp));
+    // Upvote — count +1, button becomes active
+    await upvoteBtn.click();
+    await expect(upvoteBtn).toHaveClass(/vote-active/);
+    await expect(upvoteBtn).toContainText(String(initialUp + 1));
 
-  // Downvote — downvote count +1
-  await downvoteBtn.click();
-  await expect(downvoteBtn).toContainText(String(initialDown + 1));
+    // Toggle off — count returns to original
+    await upvoteBtn.click();
+    await expect(upvoteBtn).not.toHaveClass(/vote-active/);
+    await expect(upvoteBtn).toContainText(String(initialUp));
 
-  // Reload — state persisted
-  await page.reload();
-  await expect(downvoteBtn).toContainText(String(initialDown + 1));
-  await expect(downvoteBtn).toHaveClass(/vote-active/);
-});
+    // Downvote — downvote count +1
+    await downvoteBtn.click();
+    await expect(downvoteBtn).toContainText(String(initialDown + 1));
+
+    // Reload — state persisted
+    await page.reload();
+    await expect(downvoteBtn).toContainText(String(initialDown + 1));
+    await expect(downvoteBtn).toHaveClass(/vote-active/);
+  });
+
+}); // end describe.serial

--- a/frontend/tests/e2e/help-requests.spec.ts
+++ b/frontend/tests/e2e/help-requests.spec.ts
@@ -1,94 +1,102 @@
 /**
  * TC-HELP-001: Standard user creates a help request; status shows OPEN.
- * TC-HELP-002: Expert comments; status changes to Expert Responding.
+ * TC-HELP-002: Expert takes on request; status changes to Expert Responding.
  * TC-HELP-003: Author marks request as resolved; button disappears for others.
+ *
+ * Tests run serially so requestUrl set in TC-HELP-001 is available to later tests.
  */
 
 import { test, expect } from '@playwright/test';
-import { createUser, loginAs, logout, uniqueEmail, UserData } from './helpers/users';
+import { createUser, loginAs, logout, uniqueEmail, uniqueTitle, UserData } from './helpers/users';
 
 let std: UserData;
 let exp: UserData;
 let requestUrl: string;
+let requestTitle: string;
 
-test.beforeAll(async ({ request }) => {
-  std = { email: uniqueEmail('help-std'), password: 'TestPass123!', full_name: 'Help Std User', role: 'STANDARD' };
-  exp = { email: uniqueEmail('help-exp'), password: 'TestPass123!', full_name: 'Help Exp User', role: 'EXPERT', category_id: 1 };
-  await createUser(request, std);
-  await createUser(request, exp);
-});
+test.describe.serial('Help Request flows', () => {
 
-// ── TC-HELP-001 ───────────────────────────────────────────────────────────────
+  test.beforeAll(async ({ request }) => {
+    std = { email: uniqueEmail('help-std'), password: 'TestPass123!', full_name: 'Help Std User', role: 'STANDARD' };
+    exp = { email: uniqueEmail('help-exp'), password: 'TestPass123!', full_name: 'Help Exp User', role: 'EXPERT', category_id: 1 };
+    requestTitle = uniqueTitle('Need medical assistance');
+    await createUser(request, std);
+    await createUser(request, exp);
+  });
 
-test('TC-HELP-001 — create a help request; status shows Open', async ({ page }) => {
-  await loginAs(page, std.email, std.password);
-  await page.goto('/help-requests');
+  // ── TC-HELP-001 ───────────────────────────────────────────────────────────────
 
-  await page.click('button:has-text("+ New Request")');
-  await page.waitForURL('**/help-requests/new');
+  test('TC-HELP-001 — create a help request; status shows Open', async ({ page }) => {
+    await loginAs(page, std.email, std.password);
+    await page.goto('/help-requests');
 
-  await page.fill('#title', 'Need medical assistance');
-  await page.fill('#description', 'I need help with medication delivery');
-  await page.selectOption('#category', 'MEDICAL');
-  await page.selectOption('#urgency', 'HIGH');
+    await page.click('button:has-text("+ New Request")');
+    await page.waitForURL('**/help-requests/new');
 
-  await page.click('button:has-text("Submit Request")');
-  await page.waitForURL(/\/help-requests\/\d+/);
-  requestUrl = page.url();
+    await page.fill('#title', requestTitle);
+    await page.fill('#description', 'I need help with medication delivery');
+    await page.selectOption('#category', 'MEDICAL');
+    await page.selectOption('#urgency', 'HIGH');
 
-  // Detail page shows correct content and Open status
-  await expect(page.getByText('Need medical assistance')).toBeVisible();
-  await expect(page.locator('.badge').filter({ hasText: /open/i })).toBeVisible();
+    await page.click('button:has-text("Submit Request")');
+    await page.waitForURL(/\/help-requests\/\d+/);
+    requestUrl = page.url();
 
-  // Also appears in the list
-  await page.goto('/help-requests');
-  await expect(page.getByText('Need medical assistance')).toBeVisible();
-});
+    // Detail page shows correct content and Open status
+    await expect(page.getByText(requestTitle)).toBeVisible();
+    await expect(page.locator('.badge').filter({ hasText: /open/i })).toBeVisible();
 
-// ── TC-HELP-002 ───────────────────────────────────────────────────────────────
+    // Also appears in the list
+    await page.goto('/help-requests');
+    await expect(page.getByText(requestTitle)).toBeVisible();
+  });
 
-test('TC-HELP-002 — expert comments; status becomes Expert Responding', async ({ page }) => {
-  await loginAs(page, exp.email, exp.password);
-  await page.goto(requestUrl);
+  // ── TC-HELP-002 ───────────────────────────────────────────────────────────────
 
-  await expect(page.locator('.badge').filter({ hasText: /open/i })).toBeVisible();
+  test('TC-HELP-002 — expert takes on request; status becomes Expert Responding', async ({ page }) => {
+    await loginAs(page, exp.email, exp.password);
+    await page.goto(requestUrl);
 
-  // Expert posts a comment
-  await page.fill('.help-detail-textarea', 'I can help — contact me at 0555-xxx');
-  await page.click('button:has-text("Post Comment")');
-  await expect(page.getByText('I can help — contact me at 0555-xxx')).toBeVisible();
+    await expect(page.locator('.badge').filter({ hasText: /open/i })).toBeVisible();
 
-  // Status updates after expert comment
-  await page.reload();
-  await expect(page.locator('.badge').filter({ hasText: /expert responding/i })).toBeVisible();
+    // Expert posts a comment
+    await page.fill('.help-detail-textarea', 'I can help — contact me at 0555-xxx');
+    await page.click('button:has-text("Post Comment")');
+    await expect(page.getByText('I can help — contact me at 0555-xxx')).toBeVisible();
 
-  // Standard user sees the same status and the comment
-  await logout(page);
-  await loginAs(page, std.email, std.password);
-  await page.goto(requestUrl);
-  await expect(page.locator('.badge').filter({ hasText: /expert responding/i })).toBeVisible();
-  await expect(page.getByText('I can help — contact me at 0555-xxx')).toBeVisible();
-});
+    // Expert takes on the request — this sets is_expert_responding = true
+    await page.click('button:has-text("Take On Request")');
+    await expect(page.locator('.badge').filter({ hasText: /expert responding/i })).toBeVisible();
 
-// ── TC-HELP-003 ───────────────────────────────────────────────────────────────
+    // Standard user sees the same status and the comment
+    await logout(page);
+    await loginAs(page, std.email, std.password);
+    await page.goto(requestUrl);
+    await expect(page.locator('.badge').filter({ hasText: /expert responding/i })).toBeVisible();
+    await expect(page.getByText('I can help — contact me at 0555-xxx')).toBeVisible();
+  });
 
-test('TC-HELP-003 — author marks as resolved; button hidden for others', async ({ page }) => {
-  await loginAs(page, std.email, std.password);
-  await page.goto(requestUrl);
+  // ── TC-HELP-003 ───────────────────────────────────────────────────────────────
 
-  const resolveBtn = page.locator('button:has-text("Mark as Resolved")');
-  await expect(resolveBtn).toBeVisible();
-  await resolveBtn.click();
+  test('TC-HELP-003 — author marks as resolved; button hidden for others', async ({ page }) => {
+    await loginAs(page, std.email, std.password);
+    await page.goto(requestUrl);
 
-  // Status changes to Resolved
-  await expect(page.locator('.badge').filter({ hasText: /resolved/i })).toBeVisible();
+    const resolveBtn = page.locator('button:has-text("Mark as Resolved")');
+    await expect(resolveBtn).toBeVisible();
+    await resolveBtn.click();
 
-  // Resolve button is no longer shown
-  await expect(page.locator('button:has-text("Mark as Resolved")')).not.toBeVisible();
+    // Status changes to Resolved
+    await expect(page.locator('.badge').filter({ hasText: /resolved/i })).toBeVisible();
 
-  // Expert (non-author) also cannot see the resolve button
-  await logout(page);
-  await loginAs(page, exp.email, exp.password);
-  await page.goto(requestUrl);
-  await expect(page.locator('button:has-text("Mark as Resolved")')).not.toBeVisible();
-});
+    // Resolve button is no longer shown
+    await expect(page.locator('button:has-text("Mark as Resolved")')).not.toBeVisible();
+
+    // Expert (non-author) also cannot see the resolve button
+    await logout(page);
+    await loginAs(page, exp.email, exp.password);
+    await page.goto(requestUrl);
+    await expect(page.locator('button:has-text("Mark as Resolved")')).not.toBeVisible();
+  });
+
+}); // end describe.serial

--- a/frontend/tests/e2e/helpers/users.ts
+++ b/frontend/tests/e2e/helpers/users.ts
@@ -15,6 +15,11 @@ export function uniqueEmail(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}@e2e.test`;
 }
 
+/** Returns a unique title/name to prevent duplicate-content collisions across runs. */
+export function uniqueTitle(prefix: string): string {
+  return `${prefix} ${Date.now()}`;
+}
+
 /**
  * Creates a user via the Django register API.
  * hub_id is omitted — optional in the backend, keeps tests hub-independent.

--- a/frontend/tests/e2e/profile.spec.ts
+++ b/frontend/tests/e2e/profile.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { createUser, loginAs, logout, uniqueEmail, UserData } from './helpers/users';
+import { createUser, loginAs, logout, uniqueEmail, uniqueTitle, UserData } from './helpers/users';
 
 let std: UserData;
 let exp: UserData;
@@ -71,15 +71,16 @@ test('expertise accordion is visible for expert user', async ({ page }) => {
 // ── Authorization guard ───────────────────────────────────────────────────────
 
 test('another user cannot edit or delete a post they did not create', async ({ page }) => {
+  const postTitle = uniqueTitle('Auth guard test post');
   // std creates a forum post
   await loginAs(page, std.email, std.password);
   await page.goto('/forum/new');
-  await page.fill('#title', 'Auth guard test post');
+  await page.fill('#title', postTitle);
   await page.fill('#content', 'This post belongs to std.');
   await page.click('button:has-text("Create Post")');
   // PostCreatePage navigates to /forum?tab=GLOBAL on success, not the post detail
   await page.waitForURL(/\/forum/);
-  await page.locator('.post-card-title').filter({ hasText: 'Auth guard test post' }).click();
+  await page.locator('.post-card-title').filter({ hasText: postTitle }).click();
   await page.waitForURL(/\/forum\/posts\/\d+/);
   const postUrl = page.url();
 

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/HelpRequestModels.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/HelpRequestModels.kt
@@ -39,11 +39,11 @@ data class HelpRequestItem(
     val title: String,
     val status: String,
     @SerializedName("comment_count") val commentCount: Int,
-    @SerializedName("is_expert_responding") val isExpertResponding: Boolean?,
-    @SerializedName("assigned_expert") val assignedExpert: HelpRequestAuthor?,
-    @SerializedName("assigned_expert_username") val assignedExpertUsername: String?,
-    @SerializedName("assigned_at") val assignedAt: String?,
-    @SerializedName("resolved_at") val resolvedAt: String?,
+    @SerializedName("is_expert_responding") val isExpertResponding: Boolean? = null,
+    @SerializedName("assigned_expert") val assignedExpert: HelpRequestAuthor? = null,
+    @SerializedName("assigned_expert_username") val assignedExpertUsername: String? = null,
+    @SerializedName("assigned_at") val assignedAt: String? = null,
+    @SerializedName("resolved_at") val resolvedAt: String? = null,
     @SerializedName("created_at") val createdAt: String
 )
 


### PR DESCRIPTION
## Description

Five independent test failures were blocking CI on the develop branch. All fixes are in test files or test infrastructure except two — a production bug in `views.py` where `_VERIFICATION_RESET_FIELDS` still referenced the deleted `field` attribute after migration `0007` removed it from the model (causing any `PATCH /expertise/<pk>` to return 500), and a mismatch in `ProfilePage.jsx` where the expertise add form was sending `category_id` but the serializer expects `category` (causing expertise field creation to always fail with 400).

**Backend:** Removed stale `expertise_field` kwarg from `StaffBase.setUp()`, fixed `ExpertiseVerificationTests` to use `category=` FK, updated `ExpertiseField` and `RegisterTests` to match current serializer shape, fixed `views.py` production bug.

**Frontend RTL:** Added missing `getMyBadges` mock to `ProfilePage.test.jsx` (introduced without a corresponding test update by PR #320). Excluded `tests/e2e/` from Jest via `testPathIgnorePatterns` to stop Playwright `.spec.ts` files from being parsed by Babel.

**Frontend e2e:** Wrapped forum and help-request flows in `test.describe.serial` to fix cross-worker variable sharing. Switched to `uniqueTitle()` for post/request titles to prevent strict-mode violations from stale DB data across runs. Fixed TC-HELP-002 to click "Take On Request" — posting a comment alone does not set `is_expert_responding`.

**Android:** Added `= null` defaults to 5 new nullable fields in `HelpRequestItem` to fix a compile-time error in `HelpRequestModelTest`.

## Related Issues

No dedicated issue — fixes pre-existing failures on the develop branch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] The commit message follows our guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [x] New and existing tests pass locally with my changes.
