### PR TITLE
fix: show expertise category name and fix mobile expertise creation

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -85,6 +85,11 @@ class ExpertiseFieldSerializer(serializers.ModelSerializer):
     """
 
     category = ExpertiseCategorySerializer(read_only=True)
+    category_id = serializers.PrimaryKeyRelatedField(
+        queryset=ExpertiseCategory.objects.filter(is_active=True),
+        source='category',
+        write_only=True,
+    )
     reviewed_by_id = serializers.PrimaryKeyRelatedField(source='reviewed_by', read_only=True)
     reviewed_by_name = serializers.SerializerMethodField()
 
@@ -93,6 +98,7 @@ class ExpertiseFieldSerializer(serializers.ModelSerializer):
         fields = [
             'id',
             'category',
+            'category_id',
             'certification_level',
             'certification_document_url',
             'verification_status',

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -84,6 +84,7 @@ class ExpertiseFieldSerializer(serializers.ModelSerializer):
     `IsVerificationCoordinatorOrAdmin` endpoints.
     """
 
+    category = ExpertiseCategorySerializer(read_only=True)
     reviewed_by_id = serializers.PrimaryKeyRelatedField(source='reviewed_by', read_only=True)
     reviewed_by_name = serializers.SerializerMethodField()
 

--- a/backend/accounts/tests.py
+++ b/backend/accounts/tests.py
@@ -589,7 +589,7 @@ class ExpertiseFieldTests(TestCase):
 
     def _create_payload(self, **overrides):
         payload = {
-            'category': self.medical_cat.pk,
+            'category_id': self.medical_cat.pk,
             'certification_level': 'ADVANCED',
         }
         payload.update(overrides)
@@ -601,7 +601,7 @@ class ExpertiseFieldTests(TestCase):
         """Expert user can add an expertise field linked to a category."""
         response = self.expert_client.post('/expertise', self._create_payload(), format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['category'], self.medical_cat.pk)
+        self.assertEqual(response.data['category']['id'], self.medical_cat.pk)
         self.assertEqual(response.data['certification_level'], 'ADVANCED')
 
     def test_expertise_field_is_approved_defaults_to_true(self):
@@ -617,7 +617,7 @@ class ExpertiseFieldTests(TestCase):
         )
         response = self.expert_client.get('/expertise')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        category_ids = [e['category'] for e in response.data]
+        category_ids = [e['category']['id'] for e in response.data]
         self.assertIn(self.shelter_cat.pk, category_ids)
 
     def test_expert_can_delete_expertise_field(self):
@@ -631,7 +631,7 @@ class ExpertiseFieldTests(TestCase):
 
     def test_expertise_defaults_certification_level_to_beginner(self):
         """Omitting certification_level defaults to BEGINNER."""
-        payload = {'category': self.medical_cat.pk}
+        payload = {'category_id': self.medical_cat.pk}
         response = self.expert_client.post('/expertise', payload, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['certification_level'], 'BEGINNER')

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -164,7 +164,7 @@ function BloodTypeSelect({ value, name, onSave, t }) {
 }
 
 const EMPTY_RESOURCE = { name: '', category: '', quantity: 1, condition: true };
-const EMPTY_EXPERTISE = { category: '', certification_level: 'BEGINNER', certification_document_url: '' };
+const EMPTY_EXPERTISE = { category_id: '', certification_level: 'BEGINNER', certification_document_url: '' };
 
 export default function ProfilePage() {
   const { user, refreshUser } = useAuth();
@@ -493,8 +493,8 @@ export default function ProfilePage() {
                       <div className="form-group">
                         <label>{t('profile.labels.field')}</label>
                         <select
-                          value={newExpertise.category}
-                          onChange={(e) => setNewExpertise((p) => ({ ...p, category: e.target.value }))}
+                          value={newExpertise.category_id}
+                          onChange={(e) => setNewExpertise((p) => ({ ...p, category_id: e.target.value }))}
                           required
                         >
                           <option value="">— {t('profile.placeholders.expertise_field')} —</option>

--- a/frontend/tests/e2e/forum.spec.ts
+++ b/frontend/tests/e2e/forum.spec.ts
@@ -69,13 +69,13 @@ test.describe.serial('Forum flows', () => {
 
     // Upvote — count +1, button becomes active
     await upvoteBtn.click();
-    await expect(upvoteBtn).toHaveClass(/vote-active/);
     await expect(upvoteBtn).toContainText(String(initialUp + 1));
+    await expect(upvoteBtn).toHaveClass(/vote-active/);
 
-    // Toggle off — count returns to original
+    // Toggle off — wait for active state to confirm API round-trip, then click
     await upvoteBtn.click();
-    await expect(upvoteBtn).not.toHaveClass(/vote-active/);
     await expect(upvoteBtn).toContainText(String(initialUp));
+    await expect(upvoteBtn).not.toHaveClass(/vote-active/);
 
     // Downvote — downvote count +1
     await downvoteBtn.click();


### PR DESCRIPTION
## Description

`ExpertiseFieldSerializer` was returning `category` as a bare integer ID instead of a nested object, so the web profile page showed only the level badge with no category name. Additionally, the serializer expected the write field to be named `category`, while the mobile app sends `category_id` — causing all mobile expertise creation attempts to fail with 400.

Fix: split the serializer field into two — `category` (read, nested `ExpertiseCategorySerializer`) and `category_id` (write-only, `PrimaryKeyRelatedField` with `source='category'`). Updated the web form to send `category_id` and updated backend tests to match the new field name and nested response shape.

## Related Issues
Fixes #340
Fixes #341

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] The commit message follows our guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [x] New and existing tests pass locally with my changes.
