### PR TITLE
feat: add mobile my posts section

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -66,6 +66,7 @@
         <activity android:name=".ui.CreateHelpOfferActivity" android:exported="false" />
         <activity android:name=".ui.ProfileActivity" android:exported="false" />
         <activity android:name=".ui.MyBadgesActivity" android:exported="false" />
+        <activity android:name=".ui.MyPostsActivity" android:exported="false" />
         <activity android:name=".ui.SettingsActivity" android:exported="false" />
         <activity android:name=".ui.ForumActivity" android:exported="false" />
         <activity android:name=".ui.CreatePostActivity" android:exported="false" />

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ApiService.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ApiService.kt
@@ -128,8 +128,9 @@ interface ApiService {
 
     @GET("forum/posts/")
     suspend fun getPosts(
-        @Query("forum_type") forumType: String,
+        @Query("forum_type") forumType: String? = null,
         @Query("hub") hub: Int? = null,
+        @Query("author") author: Int? = null,
         @Query("author_role") authorRole: String? = null
     ): Response<List<Post>>
 

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ApiService.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ApiService.kt
@@ -48,6 +48,7 @@ interface ApiService {
     suspend fun getHelpRequests(
         @Query("hub_id") hubId: Int? = null,
         @Query("category") category: String? = null,
+        @Query("author") author: Int? = null,
         @Query("expertise_match") expertiseMatch: Boolean? = null,
     ): Response<List<HelpRequestItem>>
 
@@ -105,7 +106,8 @@ interface ApiService {
     @GET("help-offers/")
     suspend fun getHelpOffers(
         @Query("hub_id") hubId: Int? = null,
-        @Query("category") category: String? = null
+        @Query("category") category: String? = null,
+        @Query("author") author: Int? = null
     ): Response<List<HelpOfferItem>>
 
     @POST("help-offers/")

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/MyPostsActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/MyPostsActivity.kt
@@ -14,20 +14,39 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.bounswe2026group8.emergencyhub.R
+import com.bounswe2026group8.emergencyhub.api.HelpOfferItem
+import com.bounswe2026group8.emergencyhub.api.HelpRequestItem
 import com.bounswe2026group8.emergencyhub.api.Post
 import com.bounswe2026group8.emergencyhub.api.RetrofitClient
 import com.bounswe2026group8.emergencyhub.api.VoteRequest
 import com.bounswe2026group8.emergencyhub.auth.TokenManager
+import com.bounswe2026group8.emergencyhub.util.BadgeUtils
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.launch
 
 class MyPostsActivity : AppCompatActivity() {
 
+    private enum class Tab {
+        FORUM_POSTS,
+        HELP_REQUESTS,
+        HELP_OFFERS
+    }
+
     private lateinit var tokenManager: TokenManager
     private lateinit var postAdapter: PostAdapter
+    private lateinit var requestAdapter: HelpRequestAdapter
+    private lateinit var offerAdapter: HelpOfferAdapter
+    private lateinit var recyclerView: RecyclerView
     private lateinit var swipeRefresh: SwipeRefreshLayout
     private lateinit var txtState: TextView
+    private lateinit var tabForumPosts: TextView
+    private lateinit var tabHelpRequests: TextView
+    private lateinit var tabHelpOffers: TextView
 
+    private var activeTab = Tab.FORUM_POSTS
     private var posts: List<Post> = emptyList()
+    private var requests: List<HelpRequestItem> = emptyList()
+    private var offers: List<HelpOfferItem> = emptyList()
 
     private val postDetailLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
@@ -36,9 +55,9 @@ class MyPostsActivity : AppCompatActivity() {
             val deletedPostId = result.data?.getIntExtra("deleted_post_id", -1) ?: -1
             if (deletedPostId != -1) {
                 posts = posts.filter { it.id != deletedPostId }
-                displayPosts()
+                displayForumPosts()
             } else {
-                loadPosts()
+                loadActiveTab()
             }
         }
     }
@@ -50,13 +69,35 @@ class MyPostsActivity : AppCompatActivity() {
         tokenManager = TokenManager(this)
         swipeRefresh = findViewById(R.id.swipeRefreshMyPosts)
         txtState = findViewById(R.id.txtMyPostsState)
+        recyclerView = findViewById(R.id.recyclerMyPosts)
+        tabForumPosts = findViewById(R.id.tabForumPosts)
+        tabHelpRequests = findViewById(R.id.tabHelpRequests)
+        tabHelpOffers = findViewById(R.id.tabHelpOffers)
 
         findViewById<TextView>(R.id.linkProfile).setOnClickListener { finish() }
         findViewById<com.google.android.material.button.MaterialButton>(R.id.btnBack).setOnClickListener { finish() }
 
-        val recycler = findViewById<RecyclerView>(R.id.recyclerMyPosts)
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        setupAdapters()
+        setupTabs()
+
+        swipeRefresh.setColorSchemeResources(R.color.accent)
+        swipeRefresh.setProgressBackgroundColorSchemeResource(R.color.bg_surface)
+        swipeRefresh.setOnRefreshListener { loadActiveTab() }
+
+        selectTab(Tab.FORUM_POSTS)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (::recyclerView.isInitialized) loadActiveTab()
+    }
+
+    private fun setupAdapters() {
+        val currentUserId = tokenManager.getUser()?.id
+
         postAdapter = PostAdapter(
-            currentUserId = tokenManager.getUser()?.id,
+            currentUserId = currentUserId,
             isLoggedIn = tokenManager.isLoggedIn(),
             onVoteClick = { postId, voteType -> handleVote(postId, voteType) },
             onRepostClick = null,
@@ -67,34 +108,77 @@ class MyPostsActivity : AppCompatActivity() {
                 postDetailLauncher.launch(intent)
             }
         )
-        recycler.layoutManager = LinearLayoutManager(this)
-        recycler.adapter = postAdapter
 
-        swipeRefresh.setColorSchemeResources(R.color.accent)
-        swipeRefresh.setProgressBackgroundColorSchemeResource(R.color.bg_surface)
-        swipeRefresh.setOnRefreshListener { loadPosts() }
+        requestAdapter = HelpRequestAdapter(emptyList()) { item ->
+            val intent = Intent(this, HelpRequestDetailActivity::class.java)
+            intent.putExtra(HelpRequestDetailActivity.EXTRA_REQUEST_ID, item.id)
+            startActivity(intent)
+        }
 
-        loadPosts()
+        offerAdapter = HelpOfferAdapter(
+            items = mutableListOf(),
+            currentUserId = currentUserId,
+            onItemClick = { showOfferDetailDialog(it) },
+            onDeleteClick = { confirmDeleteOffer(it) }
+        )
     }
 
-    override fun onResume() {
-        super.onResume()
-        loadPosts()
+    private fun setupTabs() {
+        tabForumPosts.setOnClickListener { selectTab(Tab.FORUM_POSTS) }
+        tabHelpRequests.setOnClickListener { selectTab(Tab.HELP_REQUESTS) }
+        tabHelpOffers.setOnClickListener { selectTab(Tab.HELP_OFFERS) }
     }
 
-    private fun loadPosts() {
+    private fun selectTab(tab: Tab) {
+        activeTab = tab
+        updateTabStyles()
+        recyclerView.adapter = when (tab) {
+            Tab.FORUM_POSTS -> postAdapter
+            Tab.HELP_REQUESTS -> requestAdapter
+            Tab.HELP_OFFERS -> offerAdapter
+        }
+        loadActiveTab()
+    }
+
+    private fun updateTabStyles() {
+        val tabs = mapOf(
+            Tab.FORUM_POSTS to tabForumPosts,
+            Tab.HELP_REQUESTS to tabHelpRequests,
+            Tab.HELP_OFFERS to tabHelpOffers
+        )
+
+        for ((tab, view) in tabs) {
+            if (tab == activeTab) {
+                view.setTextColor(getColor(R.color.accent))
+                view.setBackgroundResource(R.drawable.sort_pill_active_bg)
+            } else {
+                view.setTextColor(getColor(R.color.text_muted))
+                view.setBackgroundResource(R.drawable.sort_pill_bg)
+            }
+        }
+    }
+
+    private fun loadActiveTab() {
         val userId = tokenManager.getUser()?.id
         if (userId == null) {
             txtState.text = getString(R.string.my_posts_sign_in_required)
             txtState.visibility = View.VISIBLE
             swipeRefresh.isRefreshing = false
-            postAdapter.submitList(emptyList())
+            clearActiveAdapter()
             return
         }
 
         txtState.text = getString(R.string.my_posts_loading)
         txtState.visibility = View.VISIBLE
 
+        when (activeTab) {
+            Tab.FORUM_POSTS -> loadForumPosts(userId)
+            Tab.HELP_REQUESTS -> loadHelpRequests(userId)
+            Tab.HELP_OFFERS -> loadHelpOffers(userId)
+        }
+    }
+
+    private fun loadForumPosts(userId: Int) {
         lifecycleScope.launch {
             try {
                 val response = RetrofitClient.getService(this@MyPostsActivity)
@@ -104,7 +188,7 @@ class MyPostsActivity : AppCompatActivity() {
 
                 if (response.isSuccessful) {
                     posts = response.body() ?: emptyList()
-                    displayPosts()
+                    displayForumPosts()
                 } else {
                     showError()
                 }
@@ -115,17 +199,91 @@ class MyPostsActivity : AppCompatActivity() {
         }
     }
 
-    private fun displayPosts() {
+    private fun loadHelpRequests(userId: Int) {
+        lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.getService(this@MyPostsActivity)
+                    .getHelpRequests(author = userId)
+
+                swipeRefresh.isRefreshing = false
+
+                if (response.isSuccessful) {
+                    requests = response.body() ?: emptyList()
+                    displayHelpRequests()
+                } else {
+                    showError()
+                }
+            } catch (_: Exception) {
+                swipeRefresh.isRefreshing = false
+                showError()
+            }
+        }
+    }
+
+    private fun loadHelpOffers(userId: Int) {
+        lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.getService(this@MyPostsActivity)
+                    .getHelpOffers(author = userId)
+
+                swipeRefresh.isRefreshing = false
+
+                if (response.isSuccessful) {
+                    offers = response.body() ?: emptyList()
+                    displayHelpOffers()
+                } else {
+                    showError()
+                }
+            } catch (_: Exception) {
+                swipeRefresh.isRefreshing = false
+                showError()
+            }
+        }
+    }
+
+    private fun displayForumPosts() {
         val sorted = posts.sortedByDescending { it.createdAt }
         postAdapter.submitList(sorted)
-        txtState.text = getString(R.string.my_posts_empty)
-        txtState.visibility = if (sorted.isEmpty()) View.VISIBLE else View.GONE
+        showEmptyIfNeeded(sorted.isEmpty())
+    }
+
+    private fun displayHelpRequests() {
+        val sorted = requests.sortedByDescending { it.createdAt }
+        requestAdapter.updateItems(sorted)
+        showEmptyIfNeeded(sorted.isEmpty())
+    }
+
+    private fun displayHelpOffers() {
+        val sorted = offers.sortedByDescending { it.createdAt }
+        offerAdapter.updateItems(sorted)
+        showEmptyIfNeeded(sorted.isEmpty())
+    }
+
+    private fun showEmptyIfNeeded(isEmpty: Boolean) {
+        txtState.text = when (activeTab) {
+            Tab.FORUM_POSTS -> getString(R.string.my_posts_empty_forum_posts)
+            Tab.HELP_REQUESTS -> getString(R.string.my_posts_empty_help_requests)
+            Tab.HELP_OFFERS -> getString(R.string.my_posts_empty_help_offers)
+        }
+        txtState.visibility = if (isEmpty) View.VISIBLE else View.GONE
     }
 
     private fun showError() {
-        txtState.text = getString(R.string.my_posts_load_failed)
+        txtState.text = when (activeTab) {
+            Tab.FORUM_POSTS -> getString(R.string.my_posts_load_failed_forum_posts)
+            Tab.HELP_REQUESTS -> getString(R.string.my_posts_load_failed_help_requests)
+            Tab.HELP_OFFERS -> getString(R.string.my_posts_load_failed_help_offers)
+        }
         txtState.visibility = View.VISIBLE
-        Toast.makeText(this, getString(R.string.my_posts_load_failed), Toast.LENGTH_SHORT).show()
+        Toast.makeText(this, txtState.text, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun clearActiveAdapter() {
+        when (activeTab) {
+            Tab.FORUM_POSTS -> postAdapter.submitList(emptyList())
+            Tab.HELP_REQUESTS -> requestAdapter.updateItems(emptyList())
+            Tab.HELP_OFFERS -> offerAdapter.updateItems(emptyList())
+        }
     }
 
     private fun handleVote(postId: Int, voteType: String) {
@@ -191,10 +349,57 @@ class MyPostsActivity : AppCompatActivity() {
                 val response = RetrofitClient.getService(this@MyPostsActivity).deletePost(postId)
                 if (response.isSuccessful || response.code() == 204) {
                     posts = posts.filter { it.id != postId }
-                    displayPosts()
+                    displayForumPosts()
                     Toast.makeText(this@MyPostsActivity, getString(R.string.forum_post_deleted), Toast.LENGTH_SHORT).show()
                 } else {
                     Toast.makeText(this@MyPostsActivity, getString(R.string.forum_delete_failed), Toast.LENGTH_SHORT).show()
+                }
+            } catch (_: Exception) {
+                Toast.makeText(this@MyPostsActivity, getString(R.string.network_error), Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun showOfferDetailDialog(item: HelpOfferItem) {
+        val message = buildString {
+            append(getString(R.string.help_offer_detail_category_format, BadgeUtils.formatCategoryLabel(this@MyPostsActivity, item.category)))
+            append('\n')
+            append(getString(R.string.help_offer_detail_availability_format, BadgeUtils.formatAvailabilityLabel(this@MyPostsActivity, item.availability)))
+            append("\n\n")
+            append(item.description)
+            append("\n\n")
+            append(getString(R.string.help_offer_author_format, item.author.fullName))
+        }
+
+        MaterialAlertDialogBuilder(this)
+            .setTitle(item.skillOrResource)
+            .setMessage(message)
+            .setPositiveButton(getString(R.string.ok), null)
+            .show()
+    }
+
+    private fun confirmDeleteOffer(item: HelpOfferItem) {
+        MaterialAlertDialogBuilder(this)
+            .setTitle(getString(R.string.delete_offer))
+            .setMessage(getString(R.string.delete_offer_confirm))
+            .setNegativeButton(getString(R.string.cancel), null)
+            .setPositiveButton(getString(R.string.delete)) { _, _ -> deleteOffer(item) }
+            .show()
+    }
+
+    private fun deleteOffer(item: HelpOfferItem) {
+        lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.getService(this@MyPostsActivity)
+                    .deleteHelpOffer(item.id)
+
+                if (response.code() == 204 || response.isSuccessful) {
+                    offers = offers.filter { it.id != item.id }
+                    offerAdapter.removeItem(item.id)
+                    Toast.makeText(this@MyPostsActivity, getString(R.string.help_offer_deleted), Toast.LENGTH_SHORT).show()
+                    showEmptyIfNeeded(offers.isEmpty())
+                } else {
+                    Toast.makeText(this@MyPostsActivity, getString(R.string.help_offer_delete_failed), Toast.LENGTH_SHORT).show()
                 }
             } catch (_: Exception) {
                 Toast.makeText(this@MyPostsActivity, getString(R.string.network_error), Toast.LENGTH_SHORT).show()

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/MyPostsActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/MyPostsActivity.kt
@@ -1,0 +1,204 @@
+package com.bounswe2026group8.emergencyhub.ui
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.bounswe2026group8.emergencyhub.R
+import com.bounswe2026group8.emergencyhub.api.Post
+import com.bounswe2026group8.emergencyhub.api.RetrofitClient
+import com.bounswe2026group8.emergencyhub.api.VoteRequest
+import com.bounswe2026group8.emergencyhub.auth.TokenManager
+import kotlinx.coroutines.launch
+
+class MyPostsActivity : AppCompatActivity() {
+
+    private lateinit var tokenManager: TokenManager
+    private lateinit var postAdapter: PostAdapter
+    private lateinit var swipeRefresh: SwipeRefreshLayout
+    private lateinit var txtState: TextView
+
+    private var posts: List<Post> = emptyList()
+
+    private val postDetailLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val deletedPostId = result.data?.getIntExtra("deleted_post_id", -1) ?: -1
+            if (deletedPostId != -1) {
+                posts = posts.filter { it.id != deletedPostId }
+                displayPosts()
+            } else {
+                loadPosts()
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_my_posts)
+
+        tokenManager = TokenManager(this)
+        swipeRefresh = findViewById(R.id.swipeRefreshMyPosts)
+        txtState = findViewById(R.id.txtMyPostsState)
+
+        findViewById<TextView>(R.id.linkProfile).setOnClickListener { finish() }
+        findViewById<com.google.android.material.button.MaterialButton>(R.id.btnBack).setOnClickListener { finish() }
+
+        val recycler = findViewById<RecyclerView>(R.id.recyclerMyPosts)
+        postAdapter = PostAdapter(
+            currentUserId = tokenManager.getUser()?.id,
+            isLoggedIn = tokenManager.isLoggedIn(),
+            onVoteClick = { postId, voteType -> handleVote(postId, voteType) },
+            onRepostClick = null,
+            onDeleteClick = { postId -> confirmAndDeletePost(postId) },
+            onPostClick = { postId ->
+                val intent = Intent(this, PostDetailActivity::class.java)
+                intent.putExtra("post_id", postId)
+                postDetailLauncher.launch(intent)
+            }
+        )
+        recycler.layoutManager = LinearLayoutManager(this)
+        recycler.adapter = postAdapter
+
+        swipeRefresh.setColorSchemeResources(R.color.accent)
+        swipeRefresh.setProgressBackgroundColorSchemeResource(R.color.bg_surface)
+        swipeRefresh.setOnRefreshListener { loadPosts() }
+
+        loadPosts()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        loadPosts()
+    }
+
+    private fun loadPosts() {
+        val userId = tokenManager.getUser()?.id
+        if (userId == null) {
+            txtState.text = getString(R.string.my_posts_sign_in_required)
+            txtState.visibility = View.VISIBLE
+            swipeRefresh.isRefreshing = false
+            postAdapter.submitList(emptyList())
+            return
+        }
+
+        txtState.text = getString(R.string.my_posts_loading)
+        txtState.visibility = View.VISIBLE
+
+        lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.getService(this@MyPostsActivity)
+                    .getPosts(author = userId)
+
+                swipeRefresh.isRefreshing = false
+
+                if (response.isSuccessful) {
+                    posts = response.body() ?: emptyList()
+                    displayPosts()
+                } else {
+                    showError()
+                }
+            } catch (_: Exception) {
+                swipeRefresh.isRefreshing = false
+                showError()
+            }
+        }
+    }
+
+    private fun displayPosts() {
+        val sorted = posts.sortedByDescending { it.createdAt }
+        postAdapter.submitList(sorted)
+        txtState.text = getString(R.string.my_posts_empty)
+        txtState.visibility = if (sorted.isEmpty()) View.VISIBLE else View.GONE
+    }
+
+    private fun showError() {
+        txtState.text = getString(R.string.my_posts_load_failed)
+        txtState.visibility = View.VISIBLE
+        Toast.makeText(this, getString(R.string.my_posts_load_failed), Toast.LENGTH_SHORT).show()
+    }
+
+    private fun handleVote(postId: Int, voteType: String) {
+        if (!tokenManager.isLoggedIn()) {
+            Toast.makeText(this, getString(R.string.sign_in_to_vote), Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val idx = posts.indexOfFirst { it.id == postId }
+        if (idx == -1) return
+        val post = posts[idx]
+
+        var newUp = post.upvoteCount
+        var newDown = post.downvoteCount
+        var newUserVote: String? = voteType
+
+        if (post.userVote == voteType) {
+            if (voteType == "UP") newUp-- else newDown--
+            newUserVote = null
+        } else if (post.userVote != null) {
+            if (post.userVote == "UP") {
+                newUp--
+                newDown++
+            } else {
+                newDown--
+                newUp++
+            }
+        } else {
+            if (voteType == "UP") newUp++ else newDown++
+        }
+
+        val updated = post.copy(upvoteCount = newUp, downvoteCount = newDown, userVote = newUserVote)
+        posts = posts.toMutableList().also { it[idx] = updated }
+        postAdapter.updatePost(postId) { updated }
+
+        lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.getService(this@MyPostsActivity)
+                    .vote(postId, VoteRequest(voteType))
+                if (!response.isSuccessful) {
+                    posts = posts.toMutableList().also { it[idx] = post }
+                    postAdapter.updatePost(postId) { post }
+                }
+            } catch (_: Exception) {
+                posts = posts.toMutableList().also { it[idx] = post }
+                postAdapter.updatePost(postId) { post }
+            }
+        }
+    }
+
+    private fun confirmAndDeletePost(postId: Int) {
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.forum_delete_post_title))
+            .setMessage(getString(R.string.forum_delete_post_confirm))
+            .setPositiveButton(getString(R.string.delete)) { _, _ -> deletePost(postId) }
+            .setNegativeButton(getString(R.string.cancel), null)
+            .show()
+    }
+
+    private fun deletePost(postId: Int) {
+        lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.getService(this@MyPostsActivity).deletePost(postId)
+                if (response.isSuccessful || response.code() == 204) {
+                    posts = posts.filter { it.id != postId }
+                    displayPosts()
+                    Toast.makeText(this@MyPostsActivity, getString(R.string.forum_post_deleted), Toast.LENGTH_SHORT).show()
+                } else {
+                    Toast.makeText(this@MyPostsActivity, getString(R.string.forum_delete_failed), Toast.LENGTH_SHORT).show()
+                }
+            } catch (_: Exception) {
+                Toast.makeText(this@MyPostsActivity, getString(R.string.network_error), Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/ProfileActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/ProfileActivity.kt
@@ -65,6 +65,10 @@ class ProfileActivity : AppCompatActivity() {
             startActivity(Intent(this, MyBadgesActivity::class.java))
         }
 
+        findViewById<View>(R.id.cardMyPosts).setOnClickListener {
+            startActivity(Intent(this, MyPostsActivity::class.java))
+        }
+
         loadBadges()
     }
 

--- a/mobile/app/src/main/res/layout/activity_my_posts.xml
+++ b/mobile/app/src/main/res/layout/activity_my_posts.xml
@@ -34,6 +34,53 @@
             style="@style/Widget.EmergencyHub.Button.Secondary" />
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="12dp">
+
+        <TextView
+            android:id="@+id/tabForumPosts"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="2"
+            android:text="@string/my_posts_tab_forum_posts"
+            android:textColor="@color/accent"
+            android:textSize="12sp"
+            android:background="@drawable/sort_pill_active_bg"
+            android:layout_marginEnd="6dp" />
+
+        <TextView
+            android:id="@+id/tabHelpRequests"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="2"
+            android:text="@string/my_posts_tab_help_requests"
+            android:textColor="@color/text_muted"
+            android:textSize="12sp"
+            android:background="@drawable/sort_pill_bg"
+            android:layout_marginEnd="6dp" />
+
+        <TextView
+            android:id="@+id/tabHelpOffers"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:maxLines="2"
+            android:text="@string/my_posts_tab_help_offers"
+            android:textColor="@color/text_muted"
+            android:textSize="12sp"
+            android:background="@drawable/sort_pill_bg" />
+    </LinearLayout>
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/mobile/app/src/main/res/layout/activity_my_posts.xml
+++ b/mobile/app/src/main/res/layout/activity_my_posts.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/bg_base">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="12dp">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/my_posts_title"
+            android:textColor="@color/accent"
+            android:textSize="24sp"
+            android:textStyle="bold" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnBack"
+            android:layout_width="wrap_content"
+            android:layout_height="40dp"
+            android:text="@string/back_arrow"
+            android:textSize="13sp"
+            style="@style/Widget.EmergencyHub.Button.Secondary" />
+    </LinearLayout>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipeRefreshMyPosts"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerMyPosts"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingStart="20dp"
+                android:paddingEnd="20dp"
+                android:paddingBottom="8dp" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+        <TextView
+            android:id="@+id/txtMyPostsState"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:text="@string/my_posts_loading"
+            android:textColor="@color/text_muted"
+            android:textSize="15sp"
+            android:padding="20dp" />
+    </FrameLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:paddingTop="12dp"
+        android:paddingBottom="16dp"
+        android:background="@color/bg_base">
+
+        <TextView
+            android:id="@+id/linkProfile"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/back_to_profile"
+            android:textColor="@color/accent"
+            android:textSize="14sp"
+            android:padding="4dp" />
+    </LinearLayout>
+</LinearLayout>

--- a/mobile/app/src/main/res/layout/activity_profile.xml
+++ b/mobile/app/src/main/res/layout/activity_profile.xml
@@ -134,6 +134,59 @@
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 
+        <!-- My Posts Card (navigates to MyPostsActivity) -->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardMyPosts"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:clickable="true"
+            android:focusable="true"
+            app:cardBackgroundColor="@color/bg_surface"
+            app:cardCornerRadius="14dp"
+            app:strokeColor="@color/border"
+            app:strokeWidth="1dp"
+            app:cardElevation="0dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:padding="16dp">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/my_posts_title"
+                        android:textColor="@color/text_primary"
+                        android:textSize="15sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/my_posts_card_desc"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="12sp"
+                        android:layout_marginTop="2dp" />
+                </LinearLayout>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/arrow_right"
+                    android:textColor="@color/accent"
+                    android:textSize="18sp" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
         <!-- ── My Badges Card (navigates to MyBadgesActivity) ─────────── -->
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/cardMyBadges"

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -171,6 +171,15 @@
     <string name="my_posts_load_failed">No se pudieron cargar tus publicaciones</string>
     <string name="my_posts_sign_in_required">Inicia sesión para ver tus publicaciones.</string>
     <string name="back_to_profile">← Volver al perfil</string>
+    <string name="my_posts_tab_forum_posts">Publicaciones</string>
+    <string name="my_posts_tab_help_requests">Solicitudes</string>
+    <string name="my_posts_tab_help_offers">Ofertas</string>
+    <string name="my_posts_empty_forum_posts">Aún no has compartido publicaciones en el foro.</string>
+    <string name="my_posts_empty_help_requests">Aún no has creado solicitudes de ayuda.</string>
+    <string name="my_posts_empty_help_offers">Aún no has hecho ofertas de ayuda.</string>
+    <string name="my_posts_load_failed_forum_posts">No se pudieron cargar tus publicaciones del foro</string>
+    <string name="my_posts_load_failed_help_requests">No se pudieron cargar tus solicitudes de ayuda</string>
+    <string name="my_posts_load_failed_help_offers">No se pudieron cargar tus ofertas de ayuda</string>
 
     <!-- Forum -->
     <string name="forum_title">Foro</string>

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -164,6 +164,14 @@
     <string name="profile_cert_url">URL del Certificado (opcional)</string>
     <string name="profile_no_expertise">No hay campos de experiencia añadidos aún.</string>
 
+    <string name="my_posts_title">Mis publicaciones</string>
+    <string name="my_posts_card_desc">Ver las publicaciones del foro que compartiste</string>
+    <string name="my_posts_loading">Cargando tus publicaciones...</string>
+    <string name="my_posts_empty">Aún no has compartido publicaciones en el foro.</string>
+    <string name="my_posts_load_failed">No se pudieron cargar tus publicaciones</string>
+    <string name="my_posts_sign_in_required">Inicia sesión para ver tus publicaciones.</string>
+    <string name="back_to_profile">← Volver al perfil</string>
+
     <!-- Forum -->
     <string name="forum_title">Foro</string>
     <string name="forum_hub_all">Todos los hubs — todos</string>

--- a/mobile/app/src/main/res/values-tr/strings.xml
+++ b/mobile/app/src/main/res/values-tr/strings.xml
@@ -171,6 +171,15 @@
     <string name="my_posts_load_failed">Gönderilerin yüklenemedi</string>
     <string name="my_posts_sign_in_required">Gönderilerini görmek için giriş yap.</string>
     <string name="back_to_profile">← Profile Geri</string>
+    <string name="my_posts_tab_forum_posts">Forum</string>
+    <string name="my_posts_tab_help_requests">Yardım İstekleri</string>
+    <string name="my_posts_tab_help_offers">Yardım Teklifleri</string>
+    <string name="my_posts_empty_forum_posts">Henüz forum gönderisi paylaşmadın.</string>
+    <string name="my_posts_empty_help_requests">Henüz yardım isteği oluşturmadın.</string>
+    <string name="my_posts_empty_help_offers">Henüz yardım teklifi yapmadın.</string>
+    <string name="my_posts_load_failed_forum_posts">Forum gönderilerin yüklenemedi</string>
+    <string name="my_posts_load_failed_help_requests">Yardım isteklerin yüklenemedi</string>
+    <string name="my_posts_load_failed_help_offers">Yardım tekliflerin yüklenemedi</string>
 
     <!-- Forum -->
     <string name="forum_title">Forum</string>

--- a/mobile/app/src/main/res/values-tr/strings.xml
+++ b/mobile/app/src/main/res/values-tr/strings.xml
@@ -164,6 +164,14 @@
     <string name="profile_cert_url">Sertifika URL\'si (isteğe bağlı)</string>
     <string name="profile_no_expertise">Henüz uzmanlık alanı eklenmedi.</string>
 
+    <string name="my_posts_title">Gönderilerim</string>
+    <string name="my_posts_card_desc">Paylaştığın forum gönderilerini görüntüle</string>
+    <string name="my_posts_loading">Gönderilerin yükleniyor...</string>
+    <string name="my_posts_empty">Henüz forum gönderisi paylaşmadın.</string>
+    <string name="my_posts_load_failed">Gönderilerin yüklenemedi</string>
+    <string name="my_posts_sign_in_required">Gönderilerini görmek için giriş yap.</string>
+    <string name="back_to_profile">← Profile Geri</string>
+
     <!-- Forum -->
     <string name="forum_title">Forum</string>
     <string name="forum_hub_all">Tüm hub\'lar — herkes</string>

--- a/mobile/app/src/main/res/values-zh/strings.xml
+++ b/mobile/app/src/main/res/values-zh/strings.xml
@@ -171,6 +171,15 @@
     <string name="my_posts_load_failed">无法加载你的帖子</string>
     <string name="my_posts_sign_in_required">请登录后查看你的帖子。</string>
     <string name="back_to_profile">← 返回个人资料</string>
+    <string name="my_posts_tab_forum_posts">论坛帖子</string>
+    <string name="my_posts_tab_help_requests">求助请求</string>
+    <string name="my_posts_tab_help_offers">帮助提议</string>
+    <string name="my_posts_empty_forum_posts">你还没有发布任何论坛帖子。</string>
+    <string name="my_posts_empty_help_requests">你还没有创建任何求助请求。</string>
+    <string name="my_posts_empty_help_offers">你还没有发布任何帮助提议。</string>
+    <string name="my_posts_load_failed_forum_posts">无法加载你的论坛帖子</string>
+    <string name="my_posts_load_failed_help_requests">无法加载你的求助请求</string>
+    <string name="my_posts_load_failed_help_offers">无法加载你的帮助提议</string>
 
     <!-- Forum -->
     <string name="forum_title">论坛</string>

--- a/mobile/app/src/main/res/values-zh/strings.xml
+++ b/mobile/app/src/main/res/values-zh/strings.xml
@@ -164,6 +164,14 @@
     <string name="profile_cert_url">证书URL（可选）</string>
     <string name="profile_no_expertise">尚未添加专业领域。</string>
 
+    <string name="my_posts_title">我的帖子</string>
+    <string name="my_posts_card_desc">查看你发布的论坛帖子</string>
+    <string name="my_posts_loading">正在加载你的帖子...</string>
+    <string name="my_posts_empty">你还没有发布任何论坛帖子。</string>
+    <string name="my_posts_load_failed">无法加载你的帖子</string>
+    <string name="my_posts_sign_in_required">请登录后查看你的帖子。</string>
+    <string name="back_to_profile">← 返回个人资料</string>
+
     <!-- Forum -->
     <string name="forum_title">论坛</string>
     <string name="forum_hub_all">所有中心 — 所有人</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -277,6 +277,13 @@
     <string name="profile_expertise_field">Field (e.g. First Aid)</string>
     <string name="profile_cert_url">Certificate URL (optional)</string>
     <string name="profile_no_expertise">No expertise fields added yet.</string>
+    <string name="my_posts_title">My Posts</string>
+    <string name="my_posts_card_desc">View the forum posts you shared</string>
+    <string name="my_posts_loading">Loading your posts...</string>
+    <string name="my_posts_empty">You have not shared any forum posts yet.</string>
+    <string name="my_posts_load_failed">Failed to load your posts</string>
+    <string name="my_posts_sign_in_required">Sign in to view your posts.</string>
+    <string name="back_to_profile">← Back to Profile</string>
 
     <!-- Forum -->
     <string name="forum_title">Forum</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -284,6 +284,15 @@
     <string name="my_posts_load_failed">Failed to load your posts</string>
     <string name="my_posts_sign_in_required">Sign in to view your posts.</string>
     <string name="back_to_profile">← Back to Profile</string>
+    <string name="my_posts_tab_forum_posts">Forum Posts</string>
+    <string name="my_posts_tab_help_requests">Help Requests</string>
+    <string name="my_posts_tab_help_offers">Help Offers</string>
+    <string name="my_posts_empty_forum_posts">You have not shared any forum posts yet.</string>
+    <string name="my_posts_empty_help_requests">You have not created any help requests yet.</string>
+    <string name="my_posts_empty_help_offers">You have not made any help offers yet.</string>
+    <string name="my_posts_load_failed_forum_posts">Failed to load your forum posts</string>
+    <string name="my_posts_load_failed_help_requests">Failed to load your help requests</string>
+    <string name="my_posts_load_failed_help_offers">Failed to load your help offers</string>
 
     <!-- Forum -->
     <string name="forum_title">Forum</string>


### PR DESCRIPTION
## Description

This PR adds access to the “My Posts” section on the Android mobile profile page.

The implementation mirrors the existing web behavior by allowing users to view their own posts from their mobile profile. A new mobile screen was added for displaying the user’s posts, and the profile page now includes an entry point to this section.

Main changes:
- Added a “My Posts” card/entry point to the mobile profile page.
- Added `MyPostsActivity` for listing the logged-in user’s posts.
- Reused existing post adapter/navigation behavior where possible.
- Extended the mobile API call to support fetching posts by author.
- Added layout and localized strings for the new mobile section.

## Related Issues

Closes #339 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code Refactoring (no functional changes, no api changes)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] The commit message follows our guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [ ] New and existing tests pass locally with my changes.