### PR TITLE
feat: add public profile navigation and assigned expert links

### DIFF
--- a/frontend/src/pages/HelpRequestDetailPage.jsx
+++ b/frontend/src/pages/HelpRequestDetailPage.jsx
@@ -248,10 +248,10 @@ export default function HelpRequestDetailPage() {
             <span>{formatDate(helpRequest.created_at, t)}</span>
           </div>
 
-          {helpRequest.is_expert_responding && helpRequest.assigned_expert_username && (
+          {helpRequest.is_expert_responding && helpRequest.assigned_expert && (
               <div className="help-detail-assigned">
                 <span className="badge badge-expert-responding">
-                  Assigned to: {helpRequest.assigned_expert_username}
+                  Assigned to: <Link to={`/users/${helpRequest.assigned_expert.id}`} style={{ color: 'inherit', textDecoration: 'underline' }}>{helpRequest.assigned_expert_username}</Link>
                 </span>
               </div>
           )}

--- a/frontend/src/pages/HelpRequestsPage.jsx
+++ b/frontend/src/pages/HelpRequestsPage.jsx
@@ -342,9 +342,9 @@ export default function HelpRequestsPage() {
                             {req.author.role === 'EXPERT' && <span className="badge badge-expert-responding">{t('help_requests.labels.expert')}</span>}
                             <AuthorStatus profile={req.author.profile} t={t} />
                             
-                            {req.is_expert_responding && req.assigned_expert_username && (
+                            {req.is_expert_responding && req.assigned_expert && (
                                 <span className="badge badge-expert-responding">
-                                  Assigned to: {req.assigned_expert_username}
+                                  Assigned to: <Link to={`/users/${req.assigned_expert.id}`} style={{ color: 'inherit', textDecoration: 'underline' }} onClick={(e) => e.stopPropagation()}>{req.assigned_expert_username}</Link>
                                 </span>
                             )}
 

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -19,7 +19,7 @@ export default function UserProfilePage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { user: currentUser } = useAuth();
-  const { t } = useTranslation(); 
+  const { t, i18n } = useTranslation(); 
 
   const [profile, setProfile] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -230,7 +230,7 @@ export default function UserProfilePage() {
                     <li key={ef.id} className="item-card">
                       <div className="item-card-icon">🎓</div>
                       <div className="item-card-body">
-                        <span className="item-card-name">{ef.field}</span>
+                        <span className="item-card-name">{ef.category?.translations?.[i18n.language] || ef.category?.name || 'Expertise Area'}</span>
                         <span className="item-card-meta">
                     {ef.certification_level === 'ADVANCED'
                         ? `★ ${t('user_profile.expertise_item.advanced')}`

--- a/frontend/tests/e2e/forum.spec.ts
+++ b/frontend/tests/e2e/forum.spec.ts
@@ -40,7 +40,7 @@ test.describe.serial('Forum flows', () => {
     await page.click('button:has-text("Create Post")');
 
     // PostCreatePage navigates to /forum?tab=GLOBAL on success, not the post detail
-    await page.waitForURL(/\/forum/);
+    await page.waitForURL(/\/forum\?tab=/);
     await expect(page.getByText(postTitle)).toBeVisible();
 
     // Open the post detail to capture the URL for TC-FORUM-002
@@ -72,10 +72,10 @@ test.describe.serial('Forum flows', () => {
     await expect(upvoteBtn).toContainText(String(initialUp + 1));
     await expect(upvoteBtn).toHaveClass(/vote-active/);
 
-    // Toggle off — wait for active state to confirm API round-trip, then click
+    // Toggle off — wait for active class to clear (confirms API round-trip), then check count
     await upvoteBtn.click();
-    await expect(upvoteBtn).toContainText(String(initialUp));
     await expect(upvoteBtn).not.toHaveClass(/vote-active/);
+    await expect(upvoteBtn).toContainText(String(initialUp));
 
     // Downvote — downvote count +1
     await downvoteBtn.click();

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -65,6 +65,7 @@
         <activity android:name=".ui.HelpOfferListActivity" android:exported="false" />
         <activity android:name=".ui.CreateHelpOfferActivity" android:exported="false" />
         <activity android:name=".ui.ProfileActivity" android:exported="false" />
+        <activity android:name=".ui.PublicProfileActivity" android:exported="false" />
         <activity android:name=".ui.MyBadgesActivity" android:exported="false" />
         <activity android:name=".ui.MyPostsActivity" android:exported="false" />
         <activity android:name=".ui.SettingsActivity" android:exported="false" />

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ApiService.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ApiService.kt
@@ -204,6 +204,9 @@ interface ApiService {
     @PATCH("settings")
     suspend fun updateSettings(@Body body: UserSettingsUpdateRequest): Response<UserSettingsData>
 
+    @GET("users/{id}/")
+    suspend fun getUserPublicProfile(@Path("id") id: Int): Response<UserPublicProfileData>
+
     // ── Resources ───────────────────────────────────────────────────────────────
 
     @GET("resources")

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ProfileModels.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/api/ProfileModels.kt
@@ -18,6 +18,19 @@ data class ProfileData(
     @SerializedName("updated_at") val updatedAt: String?,
 )
 
+data class UserPublicProfileData(
+    val id: Int,
+    @SerializedName("full_name") val fullName: String,
+    val email: String,
+    val role: String,
+    @SerializedName("staff_role") val staffRole: String = "NONE",
+    val hub: Hub?,
+    @SerializedName("neighborhood_address") val neighborhoodAddress: String?,
+    val profile: ProfileData?,
+    val resources: List<ResourceData>?,
+    @SerializedName("expertise_fields") val expertiseFields: List<ExpertiseFieldData>?
+)
+
 data class ProfileUpdateRequest(
     @SerializedName("phone_number") val phoneNumber: String? = null,
     @SerializedName("blood_type") val bloodType: String? = null,

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/CommentAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/CommentAdapter.kt
@@ -53,6 +53,12 @@ class CommentAdapter(
 
         fun bind(comment: Comment, currentUserId: Int?, onDeleteClick: (Comment) -> Unit) {
             txtAuthor.text = comment.author.fullName
+            txtAuthor.setOnClickListener {
+                val intent = android.content.Intent(itemView.context, PublicProfileActivity::class.java).apply {
+                    putExtra(PublicProfileActivity.EXTRA_USER_ID, comment.author.id)
+                }
+                itemView.context.startActivity(intent)
+            }
             txtTime.text = TimeUtils.timeAgo(comment.createdAt)
             txtBody.text = comment.content
 

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/CommentAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/CommentAdapter.kt
@@ -54,10 +54,7 @@ class CommentAdapter(
         fun bind(comment: Comment, currentUserId: Int?, onDeleteClick: (Comment) -> Unit) {
             txtAuthor.text = comment.author.fullName
             txtAuthor.setOnClickListener {
-                val intent = android.content.Intent(itemView.context, PublicProfileActivity::class.java).apply {
-                    putExtra(PublicProfileActivity.EXTRA_USER_ID, comment.author.id)
-                }
-                itemView.context.startActivity(intent)
+                PublicProfileActivity.navigate(itemView.context, comment.author.id, currentUserId)
             }
             txtTime.text = TimeUtils.timeAgo(comment.createdAt)
             txtBody.text = comment.content

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpOfferAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpOfferAdapter.kt
@@ -48,6 +48,12 @@ class HelpOfferAdapter(
         holder.txtAvailability.text = BadgeUtils.formatAvailabilityLabel(ctx, item.availability)
         holder.txtDescription.text = item.description
         holder.txtAuthor.text = ctx.getString(R.string.help_offer_author_format, item.author.fullName)
+        holder.txtAuthor.setOnClickListener {
+            val intent = android.content.Intent(ctx, PublicProfileActivity::class.java).apply {
+                putExtra(PublicProfileActivity.EXTRA_USER_ID, item.author.id)
+            }
+            ctx.startActivity(intent)
+        }
         holder.txtTimeAgo.text = TimeUtils.timeAgo(item.createdAt)
 
         if (currentUserId != null && item.author.id == currentUserId) {

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpOfferAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpOfferAdapter.kt
@@ -49,10 +49,7 @@ class HelpOfferAdapter(
         holder.txtDescription.text = item.description
         holder.txtAuthor.text = ctx.getString(R.string.help_offer_author_format, item.author.fullName)
         holder.txtAuthor.setOnClickListener {
-            val intent = android.content.Intent(ctx, PublicProfileActivity::class.java).apply {
-                putExtra(PublicProfileActivity.EXTRA_USER_ID, item.author.id)
-            }
-            ctx.startActivity(intent)
+            PublicProfileActivity.navigate(ctx, item.author.id, currentUserId)
         }
         holder.txtTimeAgo.text = TimeUtils.timeAgo(item.createdAt)
 

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestAdapter.kt
@@ -51,6 +51,12 @@ class HelpRequestAdapter(
 
         holder.txtStatus.text = BadgeUtils.formatStatusLabel(ctx, item.status)
         holder.txtAuthor.text = item.author.fullName
+        holder.txtAuthor.setOnClickListener {
+            val intent = android.content.Intent(ctx, PublicProfileActivity::class.java).apply {
+                putExtra(PublicProfileActivity.EXTRA_USER_ID, item.author.id)
+            }
+            ctx.startActivity(intent)
+        }
         holder.txtCommentCount.text = "\uD83D\uDCAC ${item.commentCount}"
         holder.txtTimeAgo.text = TimeUtils.timeAgo(item.createdAt)
 

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestAdapter.kt
@@ -13,7 +13,8 @@ import com.bounswe2026group8.emergencyhub.util.TimeUtils
 
 class HelpRequestAdapter(
     private var items: List<HelpRequestItem>,
-    private val onItemClick: (HelpRequestItem) -> Unit
+    private val currentUserId: Int? = null,
+    private val onItemClick: (HelpRequestItem) -> Unit,
 ) : RecyclerView.Adapter<HelpRequestAdapter.ViewHolder>() {
 
     inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
@@ -52,10 +53,7 @@ class HelpRequestAdapter(
         holder.txtStatus.text = BadgeUtils.formatStatusLabel(ctx, item.status)
         holder.txtAuthor.text = item.author.fullName
         holder.txtAuthor.setOnClickListener {
-            val intent = android.content.Intent(ctx, PublicProfileActivity::class.java).apply {
-                putExtra(PublicProfileActivity.EXTRA_USER_ID, item.author.id)
-            }
-            ctx.startActivity(intent)
+            PublicProfileActivity.navigate(ctx, item.author.id, currentUserId)
         }
         holder.txtCommentCount.text = "\uD83D\uDCAC ${item.commentCount}"
         holder.txtTimeAgo.text = TimeUtils.timeAgo(item.createdAt)

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestCommentAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestCommentAdapter.kt
@@ -41,6 +41,12 @@ class HelpRequestCommentAdapter(
         val comment = items[position]
 
         holder.txtCommentAuthor.text = comment.author.fullName
+        holder.txtCommentAuthor.setOnClickListener {
+            val intent = android.content.Intent(holder.itemView.context, PublicProfileActivity::class.java).apply {
+                putExtra(PublicProfileActivity.EXTRA_USER_ID, comment.author.id)
+            }
+            holder.itemView.context.startActivity(intent)
+        }
         holder.txtCommentContent.text = comment.content
         holder.txtCommentTime.text = TimeUtils.timeAgo(comment.createdAt)
 

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestCommentAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestCommentAdapter.kt
@@ -42,10 +42,7 @@ class HelpRequestCommentAdapter(
 
         holder.txtCommentAuthor.text = comment.author.fullName
         holder.txtCommentAuthor.setOnClickListener {
-            val intent = android.content.Intent(holder.itemView.context, PublicProfileActivity::class.java).apply {
-                putExtra(PublicProfileActivity.EXTRA_USER_ID, comment.author.id)
-            }
-            holder.itemView.context.startActivity(intent)
+            PublicProfileActivity.navigate(holder.itemView.context, comment.author.id, currentUserId)
         }
         holder.txtCommentContent.text = comment.content
         holder.txtCommentTime.text = TimeUtils.timeAgo(comment.createdAt)

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestDetailActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestDetailActivity.kt
@@ -190,6 +190,12 @@ class HelpRequestDetailActivity : AppCompatActivity() {
         txtDetailTitle.text = detail.title
         txtDetailDescription.text = detail.description
         txtDetailAuthor.text = getString(R.string.help_request_author_format, detail.author.fullName)
+        txtDetailAuthor.setOnClickListener {
+            val intent = Intent(this, PublicProfileActivity::class.java).apply {
+                putExtra(PublicProfileActivity.EXTRA_USER_ID, detail.author.id)
+            }
+            startActivity(intent)
+        }
         txtDetailTimeAgo.text = TimeUtils.timeAgo(detail.createdAt)
 
         txtDetailCategory.text = BadgeUtils.formatCategoryLabel(this, detail.category)
@@ -279,8 +285,17 @@ class HelpRequestDetailActivity : AppCompatActivity() {
         if (detail.isExpertResponding == true && detail.assignedExpertUsername != null) {
             txtAssignedExpert.text = getString(R.string.assigned_expert_format, detail.assignedExpertUsername)
             txtAssignedExpert.visibility = View.VISIBLE
+            detail.assignedExpert?.id?.let { expertId ->
+                txtAssignedExpert.setOnClickListener {
+                    val intent = Intent(this, PublicProfileActivity::class.java).apply {
+                        putExtra(PublicProfileActivity.EXTRA_USER_ID, expertId)
+                    }
+                    startActivity(intent)
+                }
+            }
         } else {
             txtAssignedExpert.visibility = View.GONE
+            txtAssignedExpert.setOnClickListener(null)
         }
 
         if (isExpertUser && !isAuthor) {

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestDetailActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestDetailActivity.kt
@@ -191,10 +191,7 @@ class HelpRequestDetailActivity : AppCompatActivity() {
         txtDetailDescription.text = detail.description
         txtDetailAuthor.text = getString(R.string.help_request_author_format, detail.author.fullName)
         txtDetailAuthor.setOnClickListener {
-            val intent = Intent(this, PublicProfileActivity::class.java).apply {
-                putExtra(PublicProfileActivity.EXTRA_USER_ID, detail.author.id)
-            }
-            startActivity(intent)
+            PublicProfileActivity.navigate(this, detail.author.id, tokenManager.getUser()?.id)
         }
         txtDetailTimeAgo.text = TimeUtils.timeAgo(detail.createdAt)
 
@@ -287,10 +284,7 @@ class HelpRequestDetailActivity : AppCompatActivity() {
             txtAssignedExpert.visibility = View.VISIBLE
             detail.assignedExpert?.id?.let { expertId ->
                 txtAssignedExpert.setOnClickListener {
-                    val intent = Intent(this, PublicProfileActivity::class.java).apply {
-                        putExtra(PublicProfileActivity.EXTRA_USER_ID, expertId)
-                    }
-                    startActivity(intent)
+                    PublicProfileActivity.navigate(this, expertId, tokenManager.getUser()?.id)
                 }
             }
         } else {

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestListActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/HelpRequestListActivity.kt
@@ -88,7 +88,7 @@ class HelpRequestListActivity : AppCompatActivity() {
         }
 
         recyclerRequests.layoutManager = LinearLayoutManager(this)
-        requestAdapter = HelpRequestAdapter(emptyList()) { item ->
+        requestAdapter = HelpRequestAdapter(emptyList(), currentUserId) { item ->
             val intent = Intent(this, HelpRequestDetailActivity::class.java)
             intent.putExtra(HelpRequestDetailActivity.EXTRA_REQUEST_ID, item.id)
             startActivity(intent)

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/MyPostsActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/MyPostsActivity.kt
@@ -109,7 +109,7 @@ class MyPostsActivity : AppCompatActivity() {
             }
         )
 
-        requestAdapter = HelpRequestAdapter(emptyList()) { item ->
+        requestAdapter = HelpRequestAdapter(emptyList(), currentUserId) { item ->
             val intent = Intent(this, HelpRequestDetailActivity::class.java)
             intent.putExtra(HelpRequestDetailActivity.EXTRA_REQUEST_ID, item.id)
             startActivity(intent)

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PostAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PostAdapter.kt
@@ -85,10 +85,29 @@ class PostAdapter(
             if (post.repostedFrom != null) {
                 txtRepostLabel.text = ctx.getString(R.string.forum_reposted_by_format, post.author.fullName)
                 txtRepostLabel.visibility = View.VISIBLE
+                txtRepostLabel.setOnClickListener {
+                    val intent = Intent(ctx, PublicProfileActivity::class.java).apply {
+                        putExtra(PublicProfileActivity.EXTRA_USER_ID, post.author.id)
+                    }
+                    ctx.startActivity(intent)
+                }
                 txtAuthor.text = post.repostedFrom.author.fullName
+                txtAuthor.setOnClickListener {
+                    val intent = Intent(ctx, PublicProfileActivity::class.java).apply {
+                        putExtra(PublicProfileActivity.EXTRA_USER_ID, post.repostedFrom.author.id)
+                    }
+                    ctx.startActivity(intent)
+                }
             } else {
                 txtRepostLabel.visibility = View.GONE
+                txtRepostLabel.setOnClickListener(null)
                 txtAuthor.text = post.author.fullName
+                txtAuthor.setOnClickListener {
+                    val intent = Intent(ctx, PublicProfileActivity::class.java).apply {
+                        putExtra(PublicProfileActivity.EXTRA_USER_ID, post.author.id)
+                    }
+                    ctx.startActivity(intent)
+                }
             }
 
             txtUpvote.text = "\u25B2 ${post.upvoteCount}"

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PostAdapter.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PostAdapter.kt
@@ -86,27 +86,18 @@ class PostAdapter(
                 txtRepostLabel.text = ctx.getString(R.string.forum_reposted_by_format, post.author.fullName)
                 txtRepostLabel.visibility = View.VISIBLE
                 txtRepostLabel.setOnClickListener {
-                    val intent = Intent(ctx, PublicProfileActivity::class.java).apply {
-                        putExtra(PublicProfileActivity.EXTRA_USER_ID, post.author.id)
-                    }
-                    ctx.startActivity(intent)
+                    PublicProfileActivity.navigate(ctx, post.author.id, currentUserId)
                 }
                 txtAuthor.text = post.repostedFrom.author.fullName
                 txtAuthor.setOnClickListener {
-                    val intent = Intent(ctx, PublicProfileActivity::class.java).apply {
-                        putExtra(PublicProfileActivity.EXTRA_USER_ID, post.repostedFrom.author.id)
-                    }
-                    ctx.startActivity(intent)
+                    PublicProfileActivity.navigate(ctx, post.repostedFrom.author.id, currentUserId)
                 }
             } else {
                 txtRepostLabel.visibility = View.GONE
                 txtRepostLabel.setOnClickListener(null)
                 txtAuthor.text = post.author.fullName
                 txtAuthor.setOnClickListener {
-                    val intent = Intent(ctx, PublicProfileActivity::class.java).apply {
-                        putExtra(PublicProfileActivity.EXTRA_USER_ID, post.author.id)
-                    }
-                    ctx.startActivity(intent)
+                    PublicProfileActivity.navigate(ctx, post.author.id, currentUserId)
                 }
             }
 

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PostDetailActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PostDetailActivity.kt
@@ -137,8 +137,16 @@ class PostDetailActivity : AppCompatActivity() {
 
         findViewById<TextView>(R.id.txtHubBadge).text = p.hubName ?: getString(R.string.forum_type_global)
         findViewById<TextView>(R.id.txtPostTitle).text = p.title
-        findViewById<TextView>(R.id.txtPostAuthor).text =
-            if (p.repostedFrom != null) p.repostedFrom.author.fullName else p.author.fullName
+        findViewById<TextView>(R.id.txtPostAuthor).apply {
+            text = if (p.repostedFrom != null) p.repostedFrom.author.fullName else p.author.fullName
+            setOnClickListener {
+                val authorId = if (p.repostedFrom != null) p.repostedFrom.author.id else p.author.id
+                val intent = Intent(this@PostDetailActivity, PublicProfileActivity::class.java).apply {
+                    putExtra(PublicProfileActivity.EXTRA_USER_ID, authorId)
+                }
+                startActivity(intent)
+            }
+        }
         findViewById<TextView>(R.id.txtPostTime).text = TimeUtils.timeAgo(p.createdAt)
         findViewById<TextView>(R.id.txtPostContent).text = p.content ?: ""
 

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PostDetailActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PostDetailActivity.kt
@@ -141,10 +141,7 @@ class PostDetailActivity : AppCompatActivity() {
             text = if (p.repostedFrom != null) p.repostedFrom.author.fullName else p.author.fullName
             setOnClickListener {
                 val authorId = if (p.repostedFrom != null) p.repostedFrom.author.id else p.author.id
-                val intent = Intent(this@PostDetailActivity, PublicProfileActivity::class.java).apply {
-                    putExtra(PublicProfileActivity.EXTRA_USER_ID, authorId)
-                }
-                startActivity(intent)
+                PublicProfileActivity.navigate(this@PostDetailActivity, authorId, tokenManager.getUser()?.id)
             }
         }
         findViewById<TextView>(R.id.txtPostTime).text = TimeUtils.timeAgo(p.createdAt)

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PublicProfileActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PublicProfileActivity.kt
@@ -1,5 +1,7 @@
 package com.bounswe2026group8.emergencyhub.ui
 
+import android.content.Context
+import android.content.Intent
 import android.graphics.Typeface
 import android.os.Bundle
 import android.view.Gravity
@@ -14,6 +16,9 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.bounswe2026group8.emergencyhub.R
 import com.bounswe2026group8.emergencyhub.api.ExpertiseFieldData
+import com.bounswe2026group8.emergencyhub.api.HelpOfferItem
+import com.bounswe2026group8.emergencyhub.api.HelpRequestItem
+import com.bounswe2026group8.emergencyhub.api.Post
 import com.bounswe2026group8.emergencyhub.api.ResourceData
 import com.bounswe2026group8.emergencyhub.api.RetrofitClient
 import com.bounswe2026group8.emergencyhub.api.UserBadgeItem
@@ -26,6 +31,18 @@ class PublicProfileActivity : AppCompatActivity() {
 
     companion object {
         const val EXTRA_USER_ID = "user_id"
+
+        /** Navigates to the correct profile screen: own profile if targetUserId == currentUserId, otherwise public profile. */
+        fun navigate(context: Context, targetUserId: Int, currentUserId: Int?) {
+            if (targetUserId == currentUserId) {
+                context.startActivity(Intent(context, ProfileActivity::class.java))
+            } else {
+                context.startActivity(
+                    Intent(context, PublicProfileActivity::class.java)
+                        .putExtra(EXTRA_USER_ID, targetUserId)
+                )
+            }
+        }
     }
 
     private var userId: Int = -1
@@ -46,6 +63,20 @@ class PublicProfileActivity : AppCompatActivity() {
     private lateinit var resourceList: LinearLayout
     private lateinit var cardExpertise: View
     private lateinit var expertiseList: LinearLayout
+
+    // Activity section
+    private enum class ActivityTab { POSTS, REQUESTS, OFFERS }
+    private var activityTab = ActivityTab.POSTS
+    private var userPosts: List<Post>? = null
+    private var userRequests: List<HelpRequestItem>? = null
+    private var userOffers: List<HelpOfferItem>? = null
+
+    private lateinit var cardActivity: View
+    private lateinit var activityTabPosts: TextView
+    private lateinit var activityTabRequests: TextView
+    private lateinit var activityTabOffers: TextView
+    private lateinit var txtActivityState: TextView
+    private lateinit var activityList: LinearLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -77,8 +108,20 @@ class PublicProfileActivity : AppCompatActivity() {
         cardExpertise = findViewById(R.id.cardExpertise)
         expertiseList = findViewById(R.id.expertiseList)
 
+        cardActivity = findViewById(R.id.cardActivity)
+        activityTabPosts = findViewById(R.id.activityTabPosts)
+        activityTabRequests = findViewById(R.id.activityTabRequests)
+        activityTabOffers = findViewById(R.id.activityTabOffers)
+        txtActivityState = findViewById(R.id.txtActivityState)
+        activityList = findViewById(R.id.activityList)
+
+        activityTabPosts.setOnClickListener { selectActivityTab(ActivityTab.POSTS) }
+        activityTabRequests.setOnClickListener { selectActivityTab(ActivityTab.REQUESTS) }
+        activityTabOffers.setOnClickListener { selectActivityTab(ActivityTab.OFFERS) }
+
         loadPublicProfile()
         loadUserBadges()
+        initActivitySection()
     }
 
     private fun loadPublicProfile() {
@@ -190,11 +233,9 @@ class PublicProfileActivity : AppCompatActivity() {
         view.findViewById<TextView>(R.id.fieldLabel).text = label
         view.findViewById<TextView>(R.id.fieldValue).text = value
         
-        // Remove click listeners and edit icons (they are read-only)
-        val icon = view.findViewById<View>(R.id.editIcon)
-        if (icon != null) {
-            icon.visibility = View.GONE
-        }
+        // include_profile_field.xml has no editIcon — layout is read-only by design
+        // val icon = view.findViewById<View>(R.id.editIcon)
+        // if (icon != null) { icon.visibility = View.GONE }
         view.isClickable = false
         
         personalInfoContainer.addView(view)
@@ -261,6 +302,206 @@ class PublicProfileActivity : AppCompatActivity() {
             row.addView(label)
             expertiseList.addView(row)
         }
+    }
+
+    // ── Activity section ────────────────────────────────────────────────────
+
+    private fun initActivitySection() {
+        cardActivity.visibility = View.VISIBLE
+        selectActivityTab(ActivityTab.POSTS)
+    }
+
+    private fun selectActivityTab(tab: ActivityTab) {
+        activityTab = tab
+        updateActivityTabStyles()
+        when (tab) {
+            ActivityTab.POSTS -> if (userPosts != null) displayActivityPosts() else loadActivityPosts()
+            ActivityTab.REQUESTS -> if (userRequests != null) displayActivityRequests() else loadActivityRequests()
+            ActivityTab.OFFERS -> if (userOffers != null) displayActivityOffers() else loadActivityOffers()
+        }
+    }
+
+    private fun updateActivityTabStyles() {
+        val allTabs = listOf(
+            ActivityTab.POSTS to activityTabPosts,
+            ActivityTab.REQUESTS to activityTabRequests,
+            ActivityTab.OFFERS to activityTabOffers,
+        )
+        for ((t, view) in allTabs) {
+            if (t == activityTab) {
+                view.setTextColor(ContextCompat.getColor(this, R.color.accent))
+                view.setBackgroundResource(R.drawable.sort_pill_active_bg)
+            } else {
+                view.setTextColor(ContextCompat.getColor(this, R.color.text_muted))
+                view.setBackgroundResource(R.drawable.sort_pill_bg)
+            }
+        }
+    }
+
+    private fun loadActivityPosts() {
+        showActivityLoading()
+        lifecycleScope.launch {
+            try {
+                val res = RetrofitClient.getService(this@PublicProfileActivity).getPosts(author = userId)
+                if (res.isSuccessful) {
+                    userPosts = (res.body() ?: emptyList()).sortedByDescending { it.createdAt }
+                    if (activityTab == ActivityTab.POSTS) displayActivityPosts()
+                } else {
+                    if (activityTab == ActivityTab.POSTS) showActivityError()
+                }
+            } catch (_: Exception) {
+                if (activityTab == ActivityTab.POSTS) showActivityError()
+            }
+        }
+    }
+
+    private fun loadActivityRequests() {
+        showActivityLoading()
+        lifecycleScope.launch {
+            try {
+                val res = RetrofitClient.getService(this@PublicProfileActivity).getHelpRequests(author = userId)
+                if (res.isSuccessful) {
+                    userRequests = (res.body() ?: emptyList()).sortedByDescending { it.createdAt }
+                    if (activityTab == ActivityTab.REQUESTS) displayActivityRequests()
+                } else {
+                    if (activityTab == ActivityTab.REQUESTS) showActivityError()
+                }
+            } catch (_: Exception) {
+                if (activityTab == ActivityTab.REQUESTS) showActivityError()
+            }
+        }
+    }
+
+    private fun loadActivityOffers() {
+        showActivityLoading()
+        lifecycleScope.launch {
+            try {
+                val res = RetrofitClient.getService(this@PublicProfileActivity).getHelpOffers(author = userId)
+                if (res.isSuccessful) {
+                    userOffers = (res.body() ?: emptyList()).sortedByDescending { it.createdAt }
+                    if (activityTab == ActivityTab.OFFERS) displayActivityOffers()
+                } else {
+                    if (activityTab == ActivityTab.OFFERS) showActivityError()
+                }
+            } catch (_: Exception) {
+                if (activityTab == ActivityTab.OFFERS) showActivityError()
+            }
+        }
+    }
+
+    private fun displayActivityPosts() {
+        val posts = userPosts ?: return
+        activityList.removeAllViews()
+        if (posts.isEmpty()) {
+            showActivityEmpty(getString(R.string.profile_activity_empty_posts))
+            return
+        }
+        txtActivityState.visibility = View.GONE
+        for (post in posts) {
+            val row = buildActivityRow(
+                title = post.title,
+                meta = getString(R.string.profile_activity_post_meta, post.upvoteCount, post.downvoteCount, post.commentCount)
+            ) {
+                val intent = Intent(this, PostDetailActivity::class.java)
+                intent.putExtra("post_id", post.id)
+                startActivity(intent)
+            }
+            activityList.addView(row)
+        }
+    }
+
+    private fun displayActivityRequests() {
+        val requests = userRequests ?: return
+        activityList.removeAllViews()
+        if (requests.isEmpty()) {
+            showActivityEmpty(getString(R.string.profile_activity_empty_requests))
+            return
+        }
+        txtActivityState.visibility = View.GONE
+        for (item in requests) {
+            val statusLabel = item.status.replace('_', ' ')
+            val row = buildActivityRow(
+                title = item.title,
+                meta = getString(R.string.profile_activity_request_meta, item.category, statusLabel)
+            ) {
+                val intent = Intent(this, HelpRequestDetailActivity::class.java)
+                intent.putExtra(HelpRequestDetailActivity.EXTRA_REQUEST_ID, item.id)
+                startActivity(intent)
+            }
+            activityList.addView(row)
+        }
+    }
+
+    private fun displayActivityOffers() {
+        val offers = userOffers ?: return
+        activityList.removeAllViews()
+        if (offers.isEmpty()) {
+            showActivityEmpty(getString(R.string.profile_activity_empty_offers))
+            return
+        }
+        txtActivityState.visibility = View.GONE
+        for (item in offers) {
+            val row = buildActivityRow(
+                title = item.skillOrResource,
+                meta = getString(R.string.profile_activity_offer_meta, item.category, item.availability)
+            ) { /* offers are read-only; tap does nothing */ }
+            activityList.addView(row)
+        }
+    }
+
+    private fun buildActivityRow(title: String, meta: String, onClick: () -> Unit): View {
+        val density = resources.displayMetrics.density
+
+        val row = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(0, (10 * density).toInt(), 0, (10 * density).toInt())
+            setBackgroundColor(ContextCompat.getColor(context, android.R.color.transparent))
+            isClickable = true
+            isFocusable = true
+            setOnClickListener { onClick() }
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            ).apply { bottomMargin = 2 }
+        }
+
+        val titleView = TextView(this).apply {
+            text = title
+            textSize = 14f
+            setTextColor(ContextCompat.getColor(context, R.color.text_primary))
+        }
+
+        val metaView = TextView(this).apply {
+            text = meta
+            textSize = 12f
+            setTextColor(ContextCompat.getColor(context, R.color.text_secondary))
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            ).apply { topMargin = (2 * density).toInt() }
+        }
+
+        row.addView(titleView)
+        row.addView(metaView)
+        return row
+    }
+
+    private fun showActivityLoading() {
+        activityList.removeAllViews()
+        txtActivityState.text = getString(R.string.profile_activity_loading)
+        txtActivityState.visibility = View.VISIBLE
+    }
+
+    private fun showActivityEmpty(message: String) {
+        activityList.removeAllViews()
+        txtActivityState.text = message
+        txtActivityState.visibility = View.VISIBLE
+    }
+
+    private fun showActivityError() {
+        activityList.removeAllViews()
+        txtActivityState.text = getString(R.string.network_error)
+        txtActivityState.visibility = View.VISIBLE
     }
 
     private fun displayTopBadges(badges: List<UserBadgeItem>) {

--- a/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PublicProfileActivity.kt
+++ b/mobile/app/src/main/java/com/bounswe2026group8/emergencyhub/ui/PublicProfileActivity.kt
@@ -1,0 +1,305 @@
+package com.bounswe2026group8.emergencyhub.ui
+
+import android.graphics.Typeface
+import android.os.Bundle
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import com.bounswe2026group8.emergencyhub.R
+import com.bounswe2026group8.emergencyhub.api.ExpertiseFieldData
+import com.bounswe2026group8.emergencyhub.api.ResourceData
+import com.bounswe2026group8.emergencyhub.api.RetrofitClient
+import com.bounswe2026group8.emergencyhub.api.UserBadgeItem
+import com.bounswe2026group8.emergencyhub.api.UserPublicProfileData
+import com.bounswe2026group8.emergencyhub.util.LocaleManager
+import com.google.android.material.button.MaterialButton
+import kotlinx.coroutines.launch
+
+class PublicProfileActivity : AppCompatActivity() {
+
+    companion object {
+        const val EXTRA_USER_ID = "user_id"
+    }
+
+    private var userId: Int = -1
+
+    private lateinit var progressBar: ProgressBar
+    private lateinit var contentContainer: LinearLayout
+    
+    private lateinit var txtAvatar: TextView
+    private lateinit var txtFullName: TextView
+    private lateinit var txtEmail: TextView
+    private lateinit var txtRoleBadge: TextView
+    private lateinit var txtStatusBadge: TextView
+    private lateinit var badgesRow: LinearLayout
+
+    private lateinit var cardPersonalInfo: View
+    private lateinit var personalInfoContainer: LinearLayout
+    private lateinit var cardResources: View
+    private lateinit var resourceList: LinearLayout
+    private lateinit var cardExpertise: View
+    private lateinit var expertiseList: LinearLayout
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_public_profile)
+
+        userId = intent.getIntExtra(EXTRA_USER_ID, -1)
+        if (userId == -1) {
+            Toast.makeText(this, "Invalid user ID", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+
+        findViewById<MaterialButton>(R.id.btnBack).setOnClickListener { finish() }
+
+        progressBar = findViewById(R.id.progressBar)
+        contentContainer = findViewById(R.id.contentContainer)
+        
+        txtAvatar = findViewById(R.id.txtAvatar)
+        txtFullName = findViewById(R.id.txtFullName)
+        txtEmail = findViewById(R.id.txtEmail)
+        txtRoleBadge = findViewById(R.id.txtRoleBadge)
+        txtStatusBadge = findViewById(R.id.txtStatusBadge)
+        badgesRow = findViewById(R.id.badgesRow)
+
+        cardPersonalInfo = findViewById(R.id.cardPersonalInfo)
+        personalInfoContainer = findViewById(R.id.personalInfoContainer)
+        cardResources = findViewById(R.id.cardResources)
+        resourceList = findViewById(R.id.resourceList)
+        cardExpertise = findViewById(R.id.cardExpertise)
+        expertiseList = findViewById(R.id.expertiseList)
+
+        loadPublicProfile()
+        loadUserBadges()
+    }
+
+    private fun loadPublicProfile() {
+        progressBar.visibility = View.VISIBLE
+        contentContainer.visibility = View.GONE
+
+        lifecycleScope.launch {
+            try {
+                val res = RetrofitClient.getService(this@PublicProfileActivity).getUserPublicProfile(userId)
+                if (res.isSuccessful && res.body() != null) {
+                    displayProfile(res.body()!!)
+                } else {
+                    Toast.makeText(this@PublicProfileActivity, "Failed to load profile", Toast.LENGTH_SHORT).show()
+                    finish()
+                }
+            } catch (e: Exception) {
+                Toast.makeText(this@PublicProfileActivity, "Network error", Toast.LENGTH_SHORT).show()
+                finish()
+            } finally {
+                progressBar.visibility = View.GONE
+                contentContainer.visibility = View.VISIBLE
+            }
+        }
+    }
+
+    private fun loadUserBadges() {
+        lifecycleScope.launch {
+            try {
+                val res = RetrofitClient.getService(this@PublicProfileActivity).getUserBadges(userId)
+                if (res.isSuccessful) {
+                    val badges = res.body() ?: emptyList()
+                    val topBadges = badges
+                        .filter { it.currentLevel > 0 }
+                        .sortedByDescending { it.currentLevel }
+                        .take(3)
+                    displayTopBadges(topBadges)
+                }
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    private fun displayProfile(data: UserPublicProfileData) {
+        txtAvatar.text = data.fullName.firstOrNull()?.uppercase() ?: "?"
+        txtFullName.text = data.fullName
+        txtEmail.text = data.email
+        txtRoleBadge.text = if (data.role == "EXPERT") getString(R.string.role_expert) else getString(R.string.role_standard)
+
+        val p = data.profile
+        if (p != null) {
+            val hasPersonalInfo = p.phoneNumber != null || p.bloodType != null ||
+                    p.emergencyContact != null || p.emergencyContactPhone != null ||
+                    p.specialNeeds != null || p.bio != null || p.preferredLanguage != null
+
+            if (hasPersonalInfo) {
+                cardPersonalInfo.visibility = View.VISIBLE
+                
+                // Keep the title, remove existing fields if reloading
+                val childCount = personalInfoContainer.childCount
+                if (childCount > 1) {
+                    personalInfoContainer.removeViews(1, childCount - 1)
+                }
+
+                addField(getString(R.string.profile_phone), p.phoneNumber)
+                addField(getString(R.string.profile_blood_type), p.bloodType)
+                addField(getString(R.string.profile_emergency_contact), p.emergencyContact)
+                addField(getString(R.string.profile_emergency_phone), p.emergencyContactPhone)
+                addField(getString(R.string.profile_special_needs_label), p.specialNeeds)
+                addField(getString(R.string.profile_bio), p.bio)
+            }
+
+            if (p.availabilityStatus.isNotBlank()) {
+                txtStatusBadge.visibility = View.VISIBLE
+                val (label, colorRes) = when (p.availabilityStatus) {
+                    "NEEDS_HELP" -> getString(R.string.status_needs_help) to R.color.error
+                    "AVAILABLE_TO_HELP" -> getString(R.string.status_available) to R.color.accent
+                    else -> getString(R.string.status_safe) to R.color.success
+                }
+                txtStatusBadge.text = getString(R.string.profile_status_badge_format, label)
+                txtStatusBadge.setTextColor(ContextCompat.getColor(this, colorRes))
+            } else {
+                txtStatusBadge.visibility = View.GONE
+            }
+        }
+
+        val resList = data.resources
+        if (!resList.isNullOrEmpty()) {
+            cardResources.visibility = View.VISIBLE
+            resourceList.removeAllViews()
+            displayResources(resList)
+        } else {
+            cardResources.visibility = View.GONE
+        }
+
+        val expList = data.expertiseFields
+        if (!expList.isNullOrEmpty() && data.role == "EXPERT") {
+            cardExpertise.visibility = View.VISIBLE
+            expertiseList.removeAllViews()
+            displayExpertise(expList)
+        } else {
+            cardExpertise.visibility = View.GONE
+        }
+    }
+
+    private fun addField(label: String, value: String?) {
+        if (value.isNullOrBlank()) return
+
+        val view = LayoutInflater.from(this).inflate(R.layout.include_profile_field, personalInfoContainer, false)
+        view.findViewById<TextView>(R.id.fieldLabel).text = label
+        view.findViewById<TextView>(R.id.fieldValue).text = value
+        
+        // Remove click listeners and edit icons (they are read-only)
+        val icon = view.findViewById<View>(R.id.editIcon)
+        if (icon != null) {
+            icon.visibility = View.GONE
+        }
+        view.isClickable = false
+        
+        personalInfoContainer.addView(view)
+    }
+
+    private fun displayResources(list: List<ResourceData>) {
+        for (item in list) {
+            val row = LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                setPadding(24, 16, 24, 16)
+                setBackgroundColor(ContextCompat.getColor(context, R.color.bg_input))
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ).apply { bottomMargin = 8 }
+            }
+
+            val label = TextView(this).apply {
+                text = getString(R.string.profile_resource_item_format, item.name, item.category, item.quantity)
+                setTextColor(ContextCompat.getColor(context, R.color.text_primary))
+                textSize = 14f
+                layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            }
+
+            val condBadge = TextView(this).apply {
+                text = if (item.condition) "\u2713" else "\u2717"
+                setTextColor(ContextCompat.getColor(context, if (item.condition) R.color.success else R.color.error))
+                textSize = 16f
+                setPadding(16, 0, 16, 0)
+            }
+
+            row.addView(label)
+            row.addView(condBadge)
+            resourceList.addView(row)
+        }
+    }
+
+    private fun displayExpertise(list: List<ExpertiseFieldData>) {
+        for (item in list) {
+            val row = LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                setPadding(24, 16, 24, 16)
+                setBackgroundColor(ContextCompat.getColor(context, R.color.bg_input))
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ).apply { bottomMargin = 8 }
+            }
+
+            val level = if (item.certificationLevel == "ADVANCED") {
+                getString(R.string.profile_cert_level_advanced)
+            } else {
+                getString(R.string.profile_cert_level_beginner)
+            }
+            val label = TextView(this).apply {
+                text = getString(R.string.profile_expertise_item_format, item.category.displayName(LocaleManager.getLanguage(context)), level)
+                setTextColor(ContextCompat.getColor(context, R.color.text_primary))
+                textSize = 14f
+                layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            }
+
+            row.addView(label)
+            expertiseList.addView(row)
+        }
+    }
+
+    private fun displayTopBadges(badges: List<UserBadgeItem>) {
+        badgesRow.removeAllViews()
+        if (badges.isEmpty()) {
+            badgesRow.visibility = View.GONE
+            return
+        }
+        badgesRow.visibility = View.VISIBLE
+
+        val density = resources.displayMetrics.density
+
+        for (badge in badges) {
+            val localizedName = BadgeLocalizer.getLocalizedBadgeName(this, badge.badgeName)
+            val displayTitle = if (badge.currentLevel > 0) {
+                getString(R.string.badges_name_with_level, localizedName, badge.currentLevel)
+            } else {
+                localizedName
+            }
+
+            val pillText = getString(R.string.badges_pill_format, badge.badgeIcon, displayTitle)
+
+            val pill = TextView(this).apply {
+                text = pillText
+                textSize = 12f
+                setTypeface(typeface, Typeface.BOLD)
+                setTextColor(ContextCompat.getColor(context, R.color.accent))
+                setBackgroundColor(ContextCompat.getColor(context, R.color.badge_accent_bg))
+                setPadding(
+                    (10 * density).toInt(), (4 * density).toInt(),
+                    (10 * density).toInt(), (4 * density).toInt()
+                )
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ).apply { marginEnd = (8 * density).toInt() }
+            }
+
+            badgesRow.addView(pill)
+        }
+    }
+}

--- a/mobile/app/src/main/res/layout/activity_public_profile.xml
+++ b/mobile/app/src/main/res/layout/activity_public_profile.xml
@@ -256,6 +256,105 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- ── Activity Section (Posts / Requests / Offers) ─────────────── -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardActivity"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone"
+                app:cardBackgroundColor="@color/bg_surface"
+                app:cardCornerRadius="14dp"
+                app:strokeColor="@color/border"
+                app:strokeWidth="1dp"
+                app:cardElevation="0dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="20dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/profile_activity"
+                        android:textColor="@color/text_primary"
+                        android:textSize="15sp"
+                        android:textStyle="bold"
+                        android:layout_marginBottom="12dp" />
+
+                    <!-- Tab row -->
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:layout_marginBottom="12dp">
+
+                        <TextView
+                            android:id="@+id/activityTabPosts"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/my_posts_tab_forum_posts"
+                            android:gravity="center"
+                            android:textSize="11sp"
+                            android:paddingTop="6dp"
+                            android:paddingBottom="6dp"
+                            android:layout_marginEnd="4dp"
+                            android:background="@drawable/sort_pill_active_bg"
+                            android:textColor="@color/accent" />
+
+                        <TextView
+                            android:id="@+id/activityTabRequests"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/my_posts_tab_help_requests"
+                            android:gravity="center"
+                            android:textSize="11sp"
+                            android:paddingTop="6dp"
+                            android:paddingBottom="6dp"
+                            android:layout_marginEnd="4dp"
+                            android:background="@drawable/sort_pill_bg"
+                            android:textColor="@color/text_muted" />
+
+                        <TextView
+                            android:id="@+id/activityTabOffers"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/my_posts_tab_help_offers"
+                            android:gravity="center"
+                            android:textSize="11sp"
+                            android:paddingTop="6dp"
+                            android:paddingBottom="6dp"
+                            android:background="@drawable/sort_pill_bg"
+                            android:textColor="@color/text_muted" />
+
+                    </LinearLayout>
+
+                    <!-- State (loading / empty / error) -->
+                    <TextView
+                        android:id="@+id/txtActivityState"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="13sp"
+                        android:layout_gravity="center"
+                        android:layout_marginTop="4dp"
+                        android:visibility="gone" />
+
+                    <!-- Dynamically populated item rows -->
+                    <LinearLayout
+                        android:id="@+id/activityList"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
+
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
         </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/mobile/app/src/main/res/layout/activity_public_profile.xml
+++ b/mobile/app/src/main/res/layout/activity_public_profile.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_base">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <!-- ── Header bar ──────────────────────────────────────────────────── -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/profile_title"
+                android:textColor="@color/text_primary"
+                android:textSize="20sp"
+                android:textStyle="bold" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnBack"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:text="@string/back_arrow"
+                android:textSize="13sp"
+                style="@style/Widget.EmergencyHub.Button.Secondary" />
+        </LinearLayout>
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="32dp" />
+
+        <LinearLayout
+            android:id="@+id/contentContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <!-- ── Identity Card ───────────────────────────────────────────────── -->
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                app:cardBackgroundColor="@color/bg_surface"
+                app:cardCornerRadius="16dp"
+                app:strokeColor="@color/border"
+                app:strokeWidth="1dp"
+                app:cardElevation="0dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:padding="20dp"
+                    android:gravity="center_vertical">
+
+                    <!-- Avatar circle -->
+                    <TextView
+                        android:id="@+id/txtAvatar"
+                        android:layout_width="52dp"
+                        android:layout_height="52dp"
+                        android:gravity="center"
+                        android:text="?"
+                        android:textSize="22sp"
+                        android:textStyle="bold"
+                        android:textColor="@color/white"
+                        android:background="@drawable/avatar_circle_bg"
+                        android:layout_marginEnd="16dp" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/txtFullName"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/text_primary"
+                            android:textSize="17sp"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/txtEmail"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/text_secondary"
+                            android:textSize="13sp"
+                            android:layout_marginTop="2dp" />
+
+                        <LinearLayout
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:layout_marginTop="8dp">
+
+                            <TextView
+                                android:id="@+id/txtRoleBadge"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:textColor="@color/accent"
+                                android:textSize="12sp"
+                                android:background="@drawable/badge_bg"
+                                android:paddingStart="10dp"
+                                android:paddingEnd="10dp"
+                                android:paddingTop="3dp"
+                                android:paddingBottom="3dp"
+                                android:layout_marginEnd="8dp" />
+
+                            <TextView
+                                android:id="@+id/txtStatusBadge"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:textSize="12sp"
+                                android:background="@drawable/badge_bg"
+                                android:paddingStart="10dp"
+                                android:paddingEnd="10dp"
+                                android:paddingTop="3dp"
+                                android:paddingBottom="3dp"
+                                android:visibility="gone"/>
+                        </LinearLayout>
+
+                        <!-- Top earned badges -->
+                        <LinearLayout
+                            android:id="@+id/badgesRow"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:layout_marginTop="8dp"
+                            android:visibility="gone" />
+
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- ── Personal Info Card ──────────────────────────────────────────── -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardPersonalInfo"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone"
+                app:cardBackgroundColor="@color/bg_surface"
+                app:cardCornerRadius="14dp"
+                app:strokeColor="@color/border"
+                app:strokeWidth="1dp"
+                app:cardElevation="0dp">
+
+                <LinearLayout
+                    android:id="@+id/personalInfoContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="20dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/profile_personal_info"
+                        android:textColor="@color/text_primary"
+                        android:textSize="15sp"
+                        android:textStyle="bold"
+                        android:layout_marginBottom="14dp" />
+
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- ── Resources Section ───────────────────────────────────────────── -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardResources"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone"
+                app:cardBackgroundColor="@color/bg_surface"
+                app:cardCornerRadius="14dp"
+                app:strokeColor="@color/border"
+                app:strokeWidth="1dp"
+                app:cardElevation="0dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="20dp">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/profile_resources"
+                        android:textColor="@color/text_primary"
+                        android:textSize="15sp"
+                        android:textStyle="bold"
+                        android:layout_marginBottom="10dp" />
+
+                    <!-- Resource list -->
+                    <LinearLayout
+                        android:id="@+id/resourceList"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
+
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- ── Expertise Section (expert-only) ────────────── -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardExpertise"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:visibility="gone"
+                app:cardBackgroundColor="@color/bg_surface"
+                app:cardCornerRadius="14dp"
+                app:strokeColor="@color/border"
+                app:strokeWidth="1dp"
+                app:cardElevation="0dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="20dp">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/profile_expertise"
+                        android:textColor="@color/text_primary"
+                        android:textSize="15sp"
+                        android:textStyle="bold"
+                        android:layout_marginBottom="10dp" />
+
+                    <!-- Expertise list -->
+                    <LinearLayout
+                        android:id="@+id/expertiseList"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/mobile/app/src/main/res/values-es/strings.xml
+++ b/mobile/app/src/main/res/values-es/strings.xml
@@ -575,5 +575,15 @@
     <string name="badge_name_responder">Respondedor</string>
     <string name="badge_desc_responder">Otorgada por asumir la responsabilidad de las solicitudes de ayuda de la comunidad.</string>
     <string name="assigned_expert_format">Asignado a: %1$s</string>
+
+    <!-- Public profile: Activity section -->
+    <string name="profile_activity">Actividad</string>
+    <string name="profile_activity_loading">Cargando…</string>
+    <string name="profile_activity_empty_posts">Sin publicaciones en el foro todavía.</string>
+    <string name="profile_activity_empty_requests">Sin solicitudes de ayuda todavía.</string>
+    <string name="profile_activity_empty_offers">Sin ofertas de ayuda todavía.</string>
+    <string name="profile_activity_post_meta">▲ %1$d  ▼ %2$d  💬 %3$d</string>
+    <string name="profile_activity_request_meta">%1$s · %2$s</string>
+    <string name="profile_activity_offer_meta">%1$s · %2$s</string>
 </resources>
 

--- a/mobile/app/src/main/res/values-tr/strings.xml
+++ b/mobile/app/src/main/res/values-tr/strings.xml
@@ -599,5 +599,15 @@
     <string name="badge_name_responder">Yardımsever</string>
     <string name="badge_desc_responder">Topluluk yardım taleplerinin sorumluluğunu üstlendiğiniz için verilir.</string>
     <string name="assigned_expert_format">Atanan: %1$s</string>
+
+    <!-- Public profile: Activity section -->
+    <string name="profile_activity">Aktivite</string>
+    <string name="profile_activity_loading">Yükleniyor…</string>
+    <string name="profile_activity_empty_posts">Henüz forum gönderisi yok.</string>
+    <string name="profile_activity_empty_requests">Henüz yardım talebi yok.</string>
+    <string name="profile_activity_empty_offers">Henüz yardım teklifi yok.</string>
+    <string name="profile_activity_post_meta">▲ %1$d  ▼ %2$d  💬 %3$d</string>
+    <string name="profile_activity_request_meta">%1$s · %2$s</string>
+    <string name="profile_activity_offer_meta">%1$s · %2$s</string>
 </resources>
 

--- a/mobile/app/src/main/res/values-zh/strings.xml
+++ b/mobile/app/src/main/res/values-zh/strings.xml
@@ -575,5 +575,15 @@
     <string name="badge_name_responder">響應者</string>
     <string name="badge_desc_responder">獎勵給承擔社區求助請求責任的用戶。</string>
     <string name="assigned_expert_format">已分配给: %1$s</string>
+
+    <!-- Public profile: Activity section -->
+    <string name="profile_activity">动态</string>
+    <string name="profile_activity_loading">加载中…</string>
+    <string name="profile_activity_empty_posts">暂无论坛帖子。</string>
+    <string name="profile_activity_empty_requests">暂无求助请求。</string>
+    <string name="profile_activity_empty_offers">暂无帮助提供。</string>
+    <string name="profile_activity_post_meta">▲ %1$d  ▼ %2$d  💬 %3$d</string>
+    <string name="profile_activity_request_meta">%1$s · %2$s</string>
+    <string name="profile_activity_offer_meta">%1$s · %2$s</string>
 </resources>
 

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -705,5 +705,15 @@
     <string name="badge_name_responder">Responder</string>
     <string name="badge_desc_responder">Awarded for taking responsibility for community help requests.</string>
     <string name="assigned_expert_format">Assigned to: %1$s</string>
+
+    <!-- Public profile: Activity section -->
+    <string name="profile_activity">Activity</string>
+    <string name="profile_activity_loading">Loading…</string>
+    <string name="profile_activity_empty_posts">No forum posts yet.</string>
+    <string name="profile_activity_empty_requests">No help requests yet.</string>
+    <string name="profile_activity_empty_offers">No help offers yet.</string>
+    <string name="profile_activity_post_meta">▲ %1$d  ▼ %2$d  💬 %3$d</string>
+    <string name="profile_activity_request_meta">%1$s · %2$s</string>
+    <string name="profile_activity_offer_meta">%1$s · %2$s</string>
 </resources>
 


### PR DESCRIPTION
## Description

This PR improves user profile navigation across web and Android mobile.

Main changes:
- Made the assigned expert name clickable on help requests, so users can navigate from the “Assigned to …” label to that expert’s public profile.
- Added Android mobile public profile support.
- Made usernames tappable in relevant mobile flows such as forum posts, comments, help requests, and help offers, leading to the corresponding public profile.
- Added a read-only public profile view on mobile that respects existing privacy settings and exposes only allowed profile information.
- Updated the web public profile expertise section so expertise entries clearly show the related expertise area/category, not only the level.

The implementation follows the existing web/public profile behavior and does not allow editing another user’s profile or exposing privacy-restricted information.

## Related Issues
Closes #345
Closes #348 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code Refactoring (no functional changes, no api changes)

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] The commit message follows our guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have removed all temporary debugging statements (e.g., console.log, print).
- [x] My changes generate no new warnings or errors.
- [ ] New and existing tests pass locally with my changes.