### PR TITLE
ci: skip test jobs when merging to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   test:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -81,6 +82,7 @@ jobs:
           path: test-reports/backend/
 
   frontend-test:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -128,6 +130,7 @@ jobs:
           path: test-reports/frontend/
 
   android-test:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -169,6 +172,7 @@ jobs:
             mobile/app/build/test-results/testDebugUnitTest/
 
   android-emulator-test:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -240,6 +244,7 @@ jobs:
           path: mobile/app/build/reports/androidTests/connected/
 
   e2e:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       checks: write


### PR DESCRIPTION
## Summary
- Test jobs (`test`, `frontend-test`, `android-test`, `android-emulator-test`, `e2e`) now only run on `pull_request` and `workflow_dispatch` events
- They are skipped on `push` to `main` — tests already passed on the PR before merge
- The `deploy` job was already gated on `push` to `main`, so deploy behavior is unchanged

## Why
Every merge to `main` was re-running the full test suite (~20+ min) even though those exact commits were already tested on the PR. This change eliminates the redundant run.

## Test plan
- [ ] Open a PR targeting `main` — all 5 test jobs should run as normal
- [ ] Merge the PR — only the `deploy` job should run; test jobs should be skipped