### PR TITLE
fix: pin android emulator job to ubuntu-22.04

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -173,7 +173,7 @@ jobs:
 
   android-emulator-test:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Pins `android-emulator-test` job to `ubuntu-22.04` instead of `ubuntu-latest`
- GitHub's `ubuntu-latest` runner recently updated to Android emulator 36.5.11.0 which has a race condition: reports `sys.boot_completed=1` before the `input` service is ready, causing `adb shell input keyevent 82` to throw `ServiceNotFoundException`
- `ubuntu-22.04` uses the older stable emulator (34.x) which does not have this issue
